### PR TITLE
skip non functions in resources

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -27,6 +27,7 @@ function Resource(name, controller) {
   this.routes = [];
   // Map controller actions
   for (var action in this.actions) {
+    if (typeof this.actions[action] !== 'function') continue;
     this.routeAction(action, this.actions[action]);
   }
 };

--- a/test/lib/resource.js
+++ b/test/lib/resource.js
@@ -36,6 +36,26 @@ describe('Resource', function() {
     done();
   });
 
+  it('should skip non functions', function(done) {
+    var app = koa();
+    app.use(Router(app));
+    var resource = app.resource('forums', {
+      index: function *() {},
+      show: function *() {},
+      config: { port: 8080 }
+    });
+    resource.should.be.a('object');
+    resource.should.have.property('name', 'forums');
+    resource.should.have.property('id', 'forum');
+    resource.should.have.property('routes');
+    resource.routes.should.be.an.instanceOf(Array);
+    resource.routes.should.have.property(0);
+    resource.routes.should.have.property(1);
+    resource.routes[0].should.have.property('path', '/forums');
+    resource.routes[1].should.have.property('path', '/forums/:forum');
+    done();
+  });
+
   it('should nest resources', function(done) {
     var app = koa();
     var router = new Router(app);


### PR DESCRIPTION
``` js
var Info = module.exports = function Info(config) {
  if (!(this instanceof Info)) return new Info()
  this.config = config
}
```

`config` is now ignored since is not a method. I would also skip `_methods`
