### PR TITLE
OPTIONS support - Gracefully ignore not supported controller actions

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -84,6 +84,10 @@ resource.routeAction = function(name, action) {
       args = ['DELETE', baseTrailing + ':' + id, action];
       break;
   }
+
+  // Gracefully ignore not supported controller actions
+  if (undefined === args) return this;
+
   // Create the route for this action
   var route = Object.create(Route.prototype);
   Route.apply(route, args);


### PR DESCRIPTION
I'll push tests in a bit.

Is there a way to expose routes?
something like

``` js
/**
 * OPTIONS /resource
 */

module.exports.options = function *options() {
  this.status = 200
  // this.header['Allow'] = 'GET,POST,PUT,DELETE,OPTIONS']
  this.set('Access-Control-Allow-Origin', '*')
  this.set('Access-Control-Allow-Methods', 'POST, GET, PUT, DELETE, OPTIONS')
  this.set('Access-Control-Allow-Credentials', false)
  this.set('Access-Control-Max-Age', '86400') // 24 hours
  this.set('Access-Control-Allow-Headers', 'X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept')

  this.body = this.app.router.routes.describe('resource')
}
```

If not we should work on that
