### PR TITLE
Clarify comments in dispatch*

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -90,10 +90,15 @@ router.middleware = function() {
       this.set('Allow', Object.keys(methodsAvailable).join(", "));
     }
     else {
+      // Could not find any route matching the requested path
+      // simply yield to downstream koa middleware
       return yield next;
     }
 
-    // no match for path or method, so return 501 Not Implemented
+    // a route matched the path but not method.
+    // currently status is prepared as 204 or 405
+    // If the method is in fact unknown at the router level,
+    // send 501 Not Implemented
     if (!~router.methods.indexOf(this.method)) {
       this.status = 501;
     }


### PR DESCRIPTION
I hope these comments are more clear.
The fact that koa-router is "transparent" when no route matches the path is I think a good thing but the comments did not state it clearly.
