### PR TITLE
Make `del` available on app

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -276,7 +276,7 @@ router.match = function(path, params) {
  */
 
 router.extendApp = function(app) {
-  ['all', 'redirect', 'register', 'url'].concat(methods)
+  ['all', 'redirect', 'register', 'url', 'del'].concat(methods)
   .forEach(function(method) {
     app[method] = Router.prototype[method].bind(this);
   }, this);


### PR DESCRIPTION
The `del` alias for `delete` is not currently extended on `app`. The documentation indicates that it should be.
