### PR TITLE
Fix redirecting with route names

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -155,14 +155,18 @@ router.all = function(name, path, middleware) {
  */
 
 router.redirect = function(source, destination, code) {
+  var route;
+
   // lookup source route by name
   if (source instanceof RegExp || source[0] != '/') {
-    source = this.route(source);
+    route = this.route(source);
+    source = route ? route.path : source;
   }
 
   // lookup destination route by name
   if (destination instanceof RegExp || destination[0] != '/') {
-    destination = this.route(destination);
+    route = this.route(destination);
+    destination = route ? route.path : destination;
   }
 
   return this.all(source, function *() {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -257,6 +257,23 @@ describe('Router', function() {
       router.routes.should.include(route);
       done();
     });
+
+    it('redirects using route names', function(done) {
+      var app = koa();
+      var router = new Router(app);
+      app.use(router.middleware());
+      app.get('home', '/', function *() {});
+      app.get('sign-up-form', '/sign-up-form', function *() {});
+      var route = app.redirect('home', 'sign-up-form');
+      request(http.createServer(app.callback()))
+        .post('/')
+        .expect(301)
+        .end(function(err, res) {
+          if (err) return done(err);
+          res.header.should.have.property('location', '/sign-up-form');
+          done();
+        });
+    });
   });
 
   describe('Router#url()', function() {


### PR DESCRIPTION
I've fixed the current behavior where this is happening:

``` javascript
app.all('/login', function *() {
  this.redirect(signInRoute); // instead of signInRoute.path
  this.status = 301;
});
```
