### PR TITLE
Fix redirecting with route names

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -157,12 +157,12 @@ router.all = function(name, path, middleware) {
 router.redirect = function(source, destination, code) {
   // lookup source route by name
   if (source instanceof RegExp || source[0] != '/') {
-    source = this.route(source);
+    source = this.url(source);
   }
 
   // lookup destination route by name
   if (destination instanceof RegExp || destination[0] != '/') {
-    destination = this.route(destination);
+    destination = this.url(destination);
   }
 
   return this.all(source, function *() {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -257,6 +257,23 @@ describe('Router', function() {
       router.routes.should.include(route);
       done();
     });
+
+    it('redirects using route names', function(done) {
+      var app = koa();
+      var router = new Router(app);
+      app.use(router.middleware());
+      app.get('home', '/', function *() {});
+      app.get('sign-up-form', '/sign-up-form', function *() {});
+      var route = app.redirect('home', 'sign-up-form');
+      request(http.createServer(app.callback()))
+        .post('/')
+        .expect(301)
+        .end(function(err, res) {
+          if (err) return done(err);
+          res.header.should.have.property('location', '/sign-up-form');
+          done();
+        });
+    });
   });
 
   describe('Router#url()', function() {


### PR DESCRIPTION
I've fixed the current behavior where this is happening:

``` javascript
app.all('/login', function *() {
  this.redirect(signInRoute); // instead of signInRoute.path
  this.status = 301;
});
```

Note: I originally created a pull request that used route.path directly. I have switched to using `router.url` since it does the same but throws an exception if the route isn't found which is better IMO.

I'm not sure how this should work if there are params in the path.
