### PR TITLE
if capture is undefiend, do not decodeURIComponent

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -83,13 +83,15 @@ route.match = function(path) {
       // use parameter names for properties
       for (var len = captures.length, i=0; i<len; i++) {
         if (this.params[i]) {
-          params[this.params[i].name] = decodeURIComponent(captures[i]);
+          var c = captures[i];
+          params[this.params[i].name] = c ? decodeURIComponent(c) : '';
         }
       }
     }
     else {
       for (var i=0, len=captures.length; i<len; i++) {
-        params[i] = decodeURIComponent(captures[i]);
+        var c = captures[i];
+        params[i] = c ? decodeURIComponent(c) : '';
       }
     }
 

--- a/test/lib/route.js
+++ b/test/lib/route.js
@@ -90,6 +90,30 @@ describe('Route', function() {
         done();
       });
     });
+
+    it('should populates ctx.params with regexp captures include undefiend', function(done) {
+
+      var app = koa();
+      app.use(router(app));
+      app.get(/^\/api(\/.+)?/i, function *(next) {
+        this.should.have.property('params');
+        this.params.should.be.type('object');
+        this.params.should.have.property(0, '');
+        yield next;
+      }, function *(next) {
+        this.should.have.property('params');
+        this.params.should.be.type('object');
+        this.params.should.have.property(0, '');
+        this.status = 204;
+      });
+      request(http.createServer(app.callback()))
+      .get('/api')
+      .expect(204)
+      .end(function(err) {
+        if (err) return done(err);
+        done();
+      });
+    })
   });
 
   describe('Route#url()', function() {


### PR DESCRIPTION
see the testcase

```
'/api'.match(/^\/api(\/.+)?/)
// =>
[ '/api', undefined, index: 0, input: '/api' ]
```

and `decodeURIComponent(undefined)` get `'undefiend'`
