### PR TITLE
Add new validate() method to validate params of a non-regex route and still provide named ctx.params

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -131,19 +131,13 @@ router.del = router['delete'];
 /**
  * Register a global extension validator
  *
- * @param {String} name.
- * @param {Object} Object with regexes
+ * @param {Object} Object with array of allowed extensions or a regex object
  * @return {Route}
  * @api public
  */
 
-router.allowExtensions = function(allow, allowNoExtension) {
+router.allowExtensions = function(allow) {
   this.allowExtensionsValidator = allow;
-  this.allowNoExtension = false;
-
-  if (allowNoExtension) {
-    this.allowNoExtension = true;
-  }
 
   return this;
 };
@@ -311,15 +305,8 @@ router.match = function(path) {
   if (typeof this.allowExtensionsValidator !== 'undefined') {
     var validate = this.allowExtensionsValidator;
 
-    if (this.allowNoExtension && ext === false) {
-      // Missing extensions are allowed
-    }
-    else if (typeof validate === 'boolean') {
-      if ((validate === false && ext !== false) || (validate === true && typeof ext !== 'string')) {
-        return false;
-      }
-    } else if (Array.isArray(validate)) {
-        if (!ext || validate.indexOf(ext) === -1) {
+    if (Array.isArray(validate)) {
+        if (validate.indexOf(ext) === -1) {
           return false;
         }
     } else {
@@ -389,18 +376,6 @@ function routerValidates(route, params) {
       , param = params[name];
 
     if (typeof validate !== 'undefined') {
-      if (typeof validate === 'boolean') {
-        if (name !== 'ext') {
-          throw new Error('Boolean validation is only allowed for ext.');
-        }
-
-        if ((validate === false && param === false) || (validate === true && typeof param === 'string')) {
-          continue;
-        }
-
-        return false;
-      }
-
       if (Array.isArray(validate)) {
         if (validate.indexOf(param) >= 0) {
           continue;


### PR DESCRIPTION
This pull request
1) adds a new validate() method to the koa-router that allows you to validate a named route parameters with regexes or arrays, and still have ctx.params populated with named parameters.
2) parses out an ext and sets a ctx.params.ext variable to an ext or false if none is used
3) Allows you to validate extensions globally or on a per-route basis
## Details

Currently you can only provide a non regex route, i.e.

```
'/articles/:id'
```

or a regex route

```
/\/articles\/([0-9]+)/
```

The problem with the regex route is
 1) it's more difficult to read as the route gets longer
 2) It's more complex if you only need to validate a single named parameter
 3) You don't get the named parameters in ctx.params. Instead of ctx.params.id, you'll get ctx.params[0]

With this pull request, you can do the following:

```
app.get('articles_find', '/articles/:id/:name', middleware).validate('articles_find', { id: '[0-9]+', name: '[a-z]+' });
```

So that given the following request: /articles/10/john

You will receive

```
ctx.params = {
  id: 10,
  name: 'john',
  ext: false
}
```

You can optionally validate only the id param or only the name param. The only requirement is that any routes you choose to validate have names.

I decided to create a validate() method to avoid the existing method signature from getting too complex since some variables are optional and not everyone will want this functionality. I'm happy to rework or adjust if someone has a better way to approach this.
## Array matching

You can do in array matching like this:

```
app.get('articles_find', '/articles/:id/:name', middleware).validate('articles_find', { id: '[0-9]+', name: ['john', 'james', 'lisa'] });
```
## Extension matching (Before This Pull Request)

When this request

```
GET /articles/10.json
```

Is made against this route:

```
/articles/:id
```

The following ctx.params are returned

```
ctx.params = {
  id: '10.json'
}
```

Using the new validate() method will still fail against a regex like [0-9]+ because the .json will not match. This pull request first extracts out an extension - if any - and sets ctx.params.ext to either the extension (i.e. json) or to boolean false.
## Extension Validation

This pull request allows you to validate extensions globally or on an individual route basis (using the validate) method by passing in either an array of valid extensions, a regex string (i.e. '[0-9]+'), or a regex object( i.e. /^[0-9]+$/).

An array ensures the extension used is found in the array. Note that bool false means no extension was used.
The regex string or object will validate that the extension matches the given regex.

Global validation is done like this:

```
app.validExtensions(['json', 'csv']);
```

Or with a regex

```
app.validExtensions(/^json|csv$/);
```

You also may have an instance where you want to allow for no extensions, but validate extensions if they are used in requests. So for example, requests to /articles/:id are valid for html requests, but you will allow people to request json and csv representations if they wish. In that case you can do this:

```
app.validExtensions([false, 'json', 'csv']);
```

This works because the ext is always set to false if one is not used. This allows you to make the extension optional but enforce json or csv extensions when an extension is used.

The same extension validation used on validExtensions() also applies to an individual route like this:

```
app.get('articles_find', '/articles/:id', middleware).validate('articles_find', { ext: [false, 'json'] });
```
## Global Extension Routing and Individual Route Extension Validation

Lets say your app only allows for four types of extensions: none at all, json, xml, or rss. You can set your allowed extensions globally like this:

```
app.validExtensions([false, 'json', 'xml', 'rss']);
```

If you have an individual route that should only accept an rss extension, you can apply the more specific validator against that individual route like this:

```
app.get('articles_find', '/articles/:id', middleware).validate('articles_find', { ext: ['rss'] });
```

In this case the router would pass the global validation, but fail to match your route and return a 404 if no other routes matched.
## Extension Checking in Your Middleware/Controller

If you allow multiple extensions for a controller, because ctx.params.ext will always be available, you can do a check like this:

```
if ('json' === ctx.params.ext) {
   // Do json-specific stuff here
} else if ('rss' === ctx.params.ext) {
   // Do rss-specific stuff here
}
```
