### PR TITLE
If decodeURIComponent error happen, just return the original value.

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -84,14 +84,14 @@ route.match = function(path) {
       for (var len = captures.length, i=0; i<len; i++) {
         if (this.params[i]) {
           var c = captures[i];
-          params[this.params[i].name] = c ? decodeURIComponent(c) : c;
+          params[this.params[i].name] = c ? safeDecodeURIComponent(c) : c;
         }
       }
     }
     else {
       for (var i=0, len=captures.length; i<len; i++) {
         var c = captures[i];
-        params[i] = c ? decodeURIComponent(c) : c;
+        params[i] = c ? safeDecodeURIComponent(c) : c;
       }
     }
 
@@ -142,3 +142,19 @@ route.url = function(params) {
 
   return url;
 };
+
+/**
+ * Safe decodeURIComponent, won't throw any error.
+ * If `decodeURIComponent` error happen, just return the original value.
+ *
+ * @param {String} text
+ * @return {String} URL decode original string.
+ */
+
+function safeDecodeURIComponent(text) {
+  try {
+    return decodeURIComponent(text);
+  } catch (e) {
+    return text;
+  }
+}

--- a/test/lib/route.js
+++ b/test/lib/route.js
@@ -68,6 +68,22 @@ describe('Route', function() {
       });
     });
 
+    it('return orginal path parameters when decodeURIComponent throw error', function(done) {
+      var app = koa();
+      app.use(router(app));
+      app.get('/:category/:title', function *(next) {
+        this.should.have.property('params');
+        this.params.should.be.type('object');
+        this.params.should.have.property('category', '100%');
+        this.params.should.have.property('title', '101%');
+        this.status = 204;
+      });
+      request(http.createServer(app.callback()))
+      .get('/100%/101%')
+      .expect(204)
+      .end(done);
+    });
+
     it('populates ctx.params with regexp captures', function(done) {
       var app = koa();
       app.use(router(app));
@@ -91,8 +107,30 @@ describe('Route', function() {
       });
     });
 
-    it('populates ctx.params with regexp captures include undefiend', function(done) {
+    it('return orginal ctx.params when decodeURIComponent throw error', function(done) {
+      var app = koa();
+      app.use(router(app));
+      app.get(/^\/api\/([^\/]+)\/?/i, function *(next) {
+        this.should.have.property('params');
+        this.params.should.be.type('object');
+        this.params.should.have.property(0, '101%');
+        yield next;
+      }, function *(next) {
+        this.should.have.property('params');
+        this.params.should.be.type('object');
+        this.params.should.have.property(0, '101%');
+        this.status = 204;
+      });
+      request(http.createServer(app.callback()))
+      .get('/api/101%')
+      .expect(204)
+      .end(function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
 
+    it('populates ctx.params with regexp captures include undefiend', function(done) {
       var app = koa();
       app.use(router(app));
       app.get(/^\/api(\/.+)?/i, function *(next) {


### PR DESCRIPTION
We need to catch decodeURIComponent() error, otherise it easy to make attack
request by `GET http://hostname/foo-category/100%`.
