### PR TITLE
Show friendly error message when usage wrong.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -119,7 +119,19 @@ router.middleware = function() {
 methods.forEach(function(method) {
   router[method] = function(name, path, middleware) {
     var args = Array.prototype.slice.call(arguments);
-    args.splice(typeof path == 'function' ? 1 : 2, 0, [method]);
+    var index = 2;
+    if (args.length === 2 || typeof path == 'function') {
+      index = 1;
+    }
+    args.splice(index, 0, [method]);
+    // `app.get("/foo", controllers.notexists)` should throw friendly error message
+    for (var i = index + 1; i < args.length; i++) {
+      var mw = args[i];
+      if (typeof mw !== 'function') {
+        throw new TypeError('register ' + method + ' `' + name +
+          '` router error, `middleware` must be a function, not `' + typeof mw + '`');
+      }
+    }
 
     this.register.apply(this, args);
     return this;

--- a/test/lib/route.js
+++ b/test/lib/route.js
@@ -151,7 +151,24 @@ describe('Route', function() {
         if (err) return done(err);
         done();
       });
-    })
+    });
+
+    it('should throw friendly error message when handle not exists', function() {
+      var app = koa();
+      app.use(router(app));
+      var notexistHandle = undefined;
+      (function () {
+        app.get('/foo', notexistHandle);
+      }).should.throw('register get `/foo` router error, `middleware` must be a function, not `undefined`');
+
+      (function () {
+        app.get('foo router', '/foo', notexistHandle);
+      }).should.throw('register get `foo router` router error, `middleware` must be a function, not `undefined`');
+
+      (function () {
+        app.post('/foo', function() {}, notexistHandle);
+      }).should.throw('register post `/foo` router error, `middleware` must be a function, not `undefined`');
+    });
   });
 
   describe('Route#url()', function() {


### PR DESCRIPTION
`app.get('/foo', notexistHandle)` should throw error more friendly message, not this

``` log
TypeError: Cannot call method 'concat' of undefined
      at pathtoRegexp (/Users/mk2/git/koa-router/node_modules/path-to-regexp/index.js:33:6)
      at new Route (/Users/mk2/git/koa-router/lib/route.js:42:19)
      at Router.router.register (/Users/mk2/git/koa-router/lib/router.js:213:15)
      at Router.router.(anonymous function) [as get] (/Users/mk2/git/koa-router/lib/router.js:138:19)
      at Context.<anonymous> (/Users/mk2/git/koa-router/test/lib/route.js:160:11)
```

should be better:

``` log
TypeError: register get `/foo` router error, `middleware` must be a function, not `undefined`
      at Router.router.(anonymous function) [as get] (/Users/mk2/git/koa-router/lib/router.js:131:15)
      at Context.<anonymous> (/Users/mk2/git/koa-router/test/lib/route.js:160:11)
      at Test.Runnable.run (/Users/mk2/git/koa-router/node_modules/mocha/lib/runnable.js:221:32)
      at Runner.runTest (/Users/mk2/git/koa-router/node_modules/mocha/lib/runner.js:374:10)
      at /Users/mk2/git/koa-router/node_modules/mocha/lib/runner.js:452:12
```
