### PR TITLE
supports custom routing detect path: ctx.routerPath

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -61,10 +61,11 @@ router.middleware = function() {
       this.params = [];
     }
 
-    debug('%s %s', this.method, this.path);
+    var pathname = this.routerPath || this.path;
+    debug('%s %s', this.method, pathname);
 
     // Find routes matching requested path
-    if (matchedRoutes = router.match(this.path)) {
+    if (matchedRoutes = router.match(pathname)) {
       var methodsAvailable = {};
 
       // Find matched route for requested method

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "koa-compose": "^2.3.0"
   },
   "devDependencies": {
-    "koa": "^0.3.0",
+    "koa": "^0.10.0",
     "should": "^3.1.2",
     "mocha": "^1.17.1",
     "supertest": "^0.9.0"

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -198,6 +198,27 @@ describe('Router', function() {
     });
   });
 
+  it('supports custom routing detect path: ctx.routerPath', function(done) {
+    var app = koa();
+    var router = new Router(app);
+    app.use(function *(next) {
+      // bind helloworld.example.com/users => example.com/helloworld/users
+      var appname = this.request.hostname.split('.', 1)[0];
+      this.routerPath = '/' + appname + this.path;
+      yield *next;
+    });
+    app.use(router.middleware());
+    app.get('/helloworld/users', function *() {
+      this.body = this.method + ' ' + this.url;
+    });
+
+    request(http.createServer(app.callback()))
+    .get('/users')
+    .set('Host', 'helloworld.example.com')
+    .expect(200)
+    .expect('GET /users', done);
+  });
+
   describe('Router#[verb]()', function() {
     it('registers route specific to HTTP verb', function() {
       var app = koa();


### PR DESCRIPTION
We want to bind `helloworld.example.com/users` => `example.com/helloworld/users`
