### PR TITLE
Fix an issue with unmatched param.

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -180,7 +180,7 @@ route.param = function(param, fn) {
   var middleware = this.middleware.array;
 
   if (this.params.some(function(routeParam) {
-    return routeParam.name = param;
+    return routeParam.name == param;
   })) {
     middleware.unshift(function *(next) {
       yield fn.call(this, this.params[param], next);

--- a/test/lib/route.js
+++ b/test/lib/route.js
@@ -211,6 +211,35 @@ describe('Route', function() {
         done();
       });
     });
+
+    it('ignores params which are not matched', function(done) {
+      var app = koa();
+      var router = new Router();
+      var route = new Route('/users/:user', ['GET'], [function *(next) {
+        this.body = this.user;
+      }]);
+      route.param('user', function *(id, next) {
+        this.user = { name: 'alex' };
+        if (!id) return this.status = 404;
+        yield next;
+      });
+      route.param('title', function *(id, next) {
+        this.user = { name: 'mark' };
+        if (!id) return this.status = 404;
+        yield next;
+      });
+      router.routes.push(route);
+      app.use(router.middleware());
+      request(http.createServer(app.callback()))
+      .get('/users/3')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        res.should.have.property('body');
+        res.body.should.have.property('name', 'alex');
+        done();
+      });
+    });
   });
 
   describe('Route#url()', function() {


### PR DESCRIPTION
Hi @alexmingoia,

After playing around with `Router#param()` and `Route#param()` in your `koa-router` package, I encountered an issue with them.

In the condition for checking *_matched_ params, you use:

```
return routeParam.name = param;
```

instead of:

```
return routeParam.name == param;
```

so all params, whatever their name is, will be matched.

I created an additional test and fix this issue, please review it.
