### PR TITLE
app.getRouter() returns the router instance for use in koa-router-newrelic

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -305,8 +305,9 @@ router.extendApp = function(app) {
   var router = this;
 
   app.url = router.url.bind(router);
-  app.getMatchedRoutes = router.match.bind(router);
-
+  app.getRouter = function() {
+    return router;
+  };
 
   ['all', 'redirect', 'register', 'del', 'param']
   .concat(methods)


### PR DESCRIPTION
Any ideas on how to access the router instance without changing koa-router are very welcome.
