### PR TITLE
Add support for path prefixes.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -239,6 +239,24 @@ Router.prototype.use = function (middleware) {
 };
 
 /**
+ * Set the path prefix for a Router instance that was already initialized.
+ *
+ * @example
+ *
+ * ```javascript
+ * router.prefix('/things/:thing_id')
+ * ```
+ *
+ * @param {String} prefix
+ * @returns {Router}
+ */
+
+Router.prototype.prefix = function (prefix) {
+  this.opts.prefix = prefix;
+  return this;
+};
+
+/**
  * Returns router middleware which dispatches a route matching the request.
  *
  * @returns {Function}

--- a/lib/router.js
+++ b/lib/router.js
@@ -430,6 +430,15 @@ Router.prototype.register = function (name, path, methods, middleware) {
     middleware = Array.prototype.slice.call(arguments, 3);
   }
 
+  if ('string' === typeof path && this.opts.prefix) {
+    path = [
+      this.opts.prefix.replace(/^\/|\/$/g, ''),
+      path.replace(/^\/|\/$/g,'')
+    ].join('/');
+
+    if ('/' !== path[0]) path = '/' + path;
+  }
+
   // create route
   var route = new Route(path, methods, middleware, name, this.opts);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -9,6 +9,7 @@ var compose = require('koa-compose');
 var debug = require('debug')('koa-router');
 var HttpError = require('http-errors');
 var methods = require('methods');
+var concatRegExp = require('concat-regexp');
 var Route = require('./route');
 
 /**
@@ -428,6 +429,27 @@ Router.prototype.redirect = function (source, destination, code) {
 };
 
 /**
+ * Construct a new path from the prefix and source path.
+ *
+ * @param {String} path
+ * @returns {String|RegExp}
+ */
+Router.prototype.setPrefix = function (path) {
+  if (this.opts.prefix instanceof RegExp) {
+    path = concatRegExp(this.opts.prefix, path);
+  } else {
+    path = [
+      this.opts.prefix.replace(/^\/|\/$/g, ''),
+      path.replace(/^\/|\/$/g,'')
+    ].join('/');
+
+    if ('/' !== path[0]) path = '/' + path;
+  }
+
+  return path;
+};
+
+/**
  * Create and register a route.
  *
  * @param {String} name Optional.
@@ -448,14 +470,7 @@ Router.prototype.register = function (name, path, methods, middleware) {
     middleware = Array.prototype.slice.call(arguments, 3);
   }
 
-  if ('string' === typeof path && this.opts.prefix) {
-    path = [
-      this.opts.prefix.replace(/^\/|\/$/g, ''),
-      path.replace(/^\/|\/$/g,'')
-    ].join('/');
-
-    if ('/' !== path[0]) path = '/' + path;
-  }
+  if (this.opts.prefix) path = this.setPrefix(path);
 
   // create route
   var route = new Route(path, methods, middleware, name, this.opts);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "route"
   ],
   "dependencies": {
+    "concat-regexp": "0.0.6",
     "debug": "^2.1.0",
     "http-errors": "^1.3.1",
     "koa-compose": "^2.3.0",

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -572,6 +572,15 @@ describe('Router', function() {
     });
   });
 
+  describe('Router#prefix', function () {
+    it('should set opts.prefix', function () {
+      var router = Router();
+      expect(router.opts).to.not.have.key('prefix');
+      router.prefix('/things/:thing_id');
+      expect(router.opts.prefix).to.equal('/things/:thing_id');
+    });
+  })
+
   describe('Static Router#url()', function() {
     it('generates route URL', function() {
         var url = Router.url('/:category/:title', { category: 'programming', title: 'how-to-node' });

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -407,6 +407,27 @@ describe('Router', function() {
       });
     });
 
+    it('should allow setting a prefix', function (done) {
+      var app = koa();
+
+      var routes = Router({ prefix: '/things/:thing_id' });
+
+      routes.get('/list', function * (next) {
+        this.body = this.params;
+      });
+
+      app.use(routes.routes());
+
+      request(http.createServer(app.callback()))
+        .get('/things/1/list')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.body.thing_id.should.equal('1');
+          done();
+        });
+    });
+
     it('responds with 404 when has a trailing slash', function(done) {
       var app = koa();
       request(http.createServer(


### PR DESCRIPTION
This is a basic implementation of the functionality requested in #105. You might be able to improve upon it, but I think this satisfies the main requirements.

**Update:**

Added ```Router#prefix``` as a convenience method.