### PR TITLE
Fix typo in doc for nested router

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ var posts = new Router();
 
 posts.get('/', function *(next) {...});
 posts.get('/:pid', function *(next) {...});
-forums.get('/forums/:fid/posts', posts.routes());
+forums.use('/forums/:fid/posts', posts.routes());
 
 // responds to "/forums/123/posts" and "/forums/123/posts/123"
 app.use(forums.routes());


### PR DESCRIPTION
Took me 30 minutes to realize it, because `forums.get('/forums/:fid/posts', posts.routes())` will not match anything so I end up with a generic 404.

ref: https://github.com/alexmingoia/koa-router/blob/master/test/lib/router.js#L81