### PR TITLE
Improved router.url().

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -131,6 +131,7 @@ Layer.prototype.captures = function (path) {
 Layer.prototype.url = function (params) {
   var args = params;
   var url = this.path;
+  var toPath = pathToRegExp.compile(url);
 
   // argument is of form { key: val }
   if (typeof params != 'object') {
@@ -138,21 +139,16 @@ Layer.prototype.url = function (params) {
   }
 
   if (args instanceof Array) {
-    for (var len = args.length, i=0; i<len; i++) {
-      url = url.replace(/:[^\/]+/, args[i]);
+    var tokens = pathToRegExp.parse(url);
+    var replace = {};
+    for (var len = tokens.length, i=0, j=0; i<len; i++) {
+      if (tokens[i].name) replace[tokens[i].name] = args[j++];
     }
+    return toPath(replace);
   }
   else {
-    for (var key in args) {
-      url = url.replace(':' + key, args[key]);
-    }
+    return toPath(params);
   }
-
-  url.split('/').forEach(function (component) {
-    url = url.replace(component, encodeURIComponent(component));
-  });
-
-  return url;
 };
 
 /**


### PR DESCRIPTION
`router.url()` was failing for me with complex parameters (optional, regex, etc) so I've updated it to utilize Path-to-RegExp's `compile` and `parse` methods. Tests are untouched and still passing.