### PR TITLE
Fix nested routers documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ var posts = new Router();
 
 posts.get('/', function *(next) {...});
 posts.get('/:pid', function *(next) {...});
-forums.get('/forums/:fid/posts', posts.routes());
+forums.use('/forums/:fid/posts', posts.routes());
 
 // responds to "/forums/123/posts" and "/forums/123/posts/123"
 app.use(forums.routes());


### PR DESCRIPTION
I'm pretty sure this is supposed to be `.use` instead of `.get`.