### PR TITLE
Pass prefix to layer for debug printing route creation

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -62,7 +62,7 @@ function Layer(path, methods, middleware, opts) {
   this.path = path;
   this.regexp = pathToRegExp(path, this.paramNames, this.opts);
 
-  debug('defined route %s %s', this.methods, this.path);
+  debug('defined route %s %s', this.methods, this.opts.prefix+this.path);
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -493,7 +493,8 @@ Router.prototype.register = function (path, methods, middleware, opts) {
     end: opts.end === false ? opts.end : true,
     name: opts.name,
     sensitive: opts.sensitive || this.opts.sensitive || false,
-    strict: opts.strict || this.opts.strict || false
+    strict: opts.strict || this.opts.strict || false,
+    prefix: opts.prefix || this.opts.prefix || "",
   });
 
   if (this.opts.prefix) {


### PR DESCRIPTION
If route has a prefix and is in debug mode, the debug message will include prefix

```javascript
var koa = require('koa'),
      r = require('koa-router')(),
      app = koa();

     r.prefix('/v1');
     r.get('/users', ...);
     app.use(r.routes());
     ....
```
*BEFORE*
```
koa-router defined route POST /users
```

*AFTER*
```
koa-router defined route POST /v1/users
```