### PR TITLE
Fixes issue when no routes are matched Router.prototype.use with no URL will not work

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -330,7 +330,9 @@ Router.prototype.routes = Router.prototype.middleware = function () {
       debug('dispatch %s %s', this.route.path, this.route.regexp);
 
       next = matched.route.middleware.call(this, next);
+    }
 
+    if (matched.middleware) {
       for (var i = 0, l = matched.middleware.length; i < l; i++) {
         next = matched.middleware[i].call(this, next);
       }


### PR DESCRIPTION
Addresses issue #161 