### PR TITLE
Allow RegExp paths as routes.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -187,7 +187,7 @@ function Router(opts) {
  *
  * @name get|put|post|patch|delete
  * @memberof module:koa-router.prototype
- * @param {String} path
+ * @param {String|RegExp} path
  * @param {Function=} middleware route middleware(s)
  * @param {Function} callback route callback
  * @returns {Router}
@@ -197,7 +197,7 @@ methods.forEach(function (method) {
   Router.prototype[method] = function (name, path, middleware) {
     var middleware;
 
-    if (typeof path === 'string') {
+    if ((typeof path === 'string') || (path instanceof RegExp)) {
       middleware = Array.prototype.slice.call(arguments, 2);
     } else {
       middleware = Array.prototype.slice.call(arguments, 1);
@@ -233,7 +233,7 @@ Router.prototype.del = Router.prototype['delete'];
  * app.use(router.routes());
  * ```
  *
- * @param {String=} path
+ * @param {String|RegExp=} path
  * @param {Function} middleware
  * @param {Function=} ...
  * @returns {Router}
@@ -244,7 +244,7 @@ Router.prototype.use = function (path, middleware) {
 
   middleware = Array.prototype.slice.call(arguments);
 
-  if (typeof path === 'string') {
+  if ((typeof path === 'string') || (path instanceof RegExp)) {
     middleware = middleware.slice(1).filter(function (fn) {
       if (fn.router) {
         // nested routers
@@ -409,7 +409,7 @@ Router.prototype.allowedMethods = function (options) {
  * Register route with all methods.
  *
  * @param {String} name Optional.
- * @param {String} path
+ * @param {String|RegExp} path
  * @param {Function=} middleware You may also pass multiple middleware.
  * @param {Function} callback
  * @returns {Router}
@@ -419,7 +419,7 @@ Router.prototype.allowedMethods = function (options) {
 Router.prototype.all = function (name, path, middleware) {
   var middleware;
 
-  if (typeof path === 'string') {
+  if ((typeof path === 'string') || (path instanceof RegExp)) {
     middleware = Array.prototype.slice.call(arguments, 2);
   } else {
     middleware = Array.prototype.slice.call(arguments, 1);
@@ -478,7 +478,7 @@ Router.prototype.redirect = function (source, destination, code) {
 /**
  * Create and register a route.
  *
- * @param {String} path Path string or regular expression.
+ * @param {String|RegExp} path Path string or regular expression.
  * @param {Array.<String>} methods Array of HTTP verbs.
  * @param {Function} middleware Multiple middleware also accepted.
  * @returns {Layer}
@@ -566,7 +566,7 @@ Router.prototype.url = function (name, params) {
 /**
  * Match given `path` and return corresponding routes.
  *
- * @param {String} path
+ * @param {String|RegExp} path
  * @param {String} method
  * @returns {Object.<layer, middleware, matched>} Returns matched route layer,
  * middleware, and all layers that matched the path.
@@ -651,7 +651,7 @@ Router.prototype.param = function (param, middleware) {
  * // => "/users/1"
  * ```
  *
- * @param {String} path url pattern
+ * @param {String|RegExp} path url pattern
  * @param {Object} params url parameters
  * @returns {String}
  */


### PR DESCRIPTION
This patch lets you use a RegExp as the path for a route.