### PR TITLE
updates for koa2.x, use compose for stacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: node_js
 node_js:
+  - "5"
   - "4"
-  - "3"
-  - "2"
-  - "1"
-  - "0.12"
 notifications:
   email:
     on_success: never

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -145,13 +145,13 @@ Layer.prototype.url = function (params) {
  *
  * ```javascript
  * router
- *   .param('user', function *(id, next) {
- *     this.user = users[id];
- *     if (!user) return this.status = 404;
- *     yield next;
+ *   .param('user', function *(id, ctx, next) {
+ *     ctx.user = users[id];
+ *     if (!user) return ctx.status = 404;
+ *     next();
  *   })
- *   .get('/users/:user', function *(next) {
- *     this.body = this.user;
+ *   .get('/users/:user', function (ctx, next) {
+ *     ctx.body = ctx.user;
  *   });
  * ```
  *
@@ -164,13 +164,8 @@ Layer.prototype.url = function (params) {
 Layer.prototype.param = function (param, fn) {
   var stack = this.stack;
   var params = this.paramNames;
-  var middleware = function *(next) {
-    next = fn.call(this, this.params[param], next);
-    if (typeof next.next === 'function') {
-      yield *next;
-    } else {
-      yield Promise.resolve(next);
-    }
+  var middleware = function (ctx, next) {
+    fn.call(this, ctx.params[param], ctx, next);
   };
   middleware.param = param;
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -6,6 +6,7 @@
  */
 
 var debug = require('debug')('koa-router');
+var compose = require('koa-compose');
 var HttpError = require('http-errors');
 var methods = require('methods');
 var Layer = require('./layer');
@@ -27,7 +28,7 @@ module.exports = Router;
  * var app = require('koa')();
  * var router = require('koa-router')();
  *
- * router.get('/', function *(next) {...});
+ * router.get('/', function (ctx, next) {...});
  *
  * app
  *   .use(router.routes())
@@ -69,16 +70,16 @@ function Router(opts) {
  *
  * ```javascript
  * router
- *   .get('/', function *(next) {
- *     this.body = 'Hello World!';
+ *   .get('/', function (ctx, next) {
+ *     ctx.body = 'Hello World!';
  *   })
- *   .post('/users', function *(next) {
+ *   .post('/users', function (ctx, next) {
  *     // ...
  *   })
- *   .put('/users/:id', function *(next) {
+ *   .put('/users/:id', function (ctx, next) {
  *     // ...
  *   })
- *   .del('/users/:id', function *(next) {
+ *   .del('/users/:id', function (ctx, next) {
  *     // ...
  *   });
  * ```
@@ -93,7 +94,7 @@ function Router(opts) {
  * renaming of URLs during development.
  *
  * ```javascript
- * router.get('user', '/users/:id', function *(next) {
+ * router.get('user', '/users/:id', function (ctx, next) {
  *  // ...
  * });
  *
@@ -108,12 +109,14 @@ function Router(opts) {
  * ```javascript
  * router.get(
  *   '/users/:id',
- *   function *(next) {
- *     this.user = yield User.findOne(this.params.id);
- *     yield next;
+ *   function (ctx, next) {
+ *     return User.findOne(ctx.params.id).then(function(user) {
+ *       ctx.user = user;
+ *       next();
+ *     });
  *   },
- *   function *(next) {
- *     console.log(this.user);
+ *   function (ctx) {
+ *     console.log(ctx.user);
  *     // => { id: 17, name: "Alex" }
  *   }
  * );
@@ -127,8 +130,8 @@ function Router(opts) {
  * var forums = new Router();
  * var posts = new Router();
  *
- * posts.get('/', function *(next) {...});
- * posts.get('/:pid', function *(next) {...});
+ * posts.get('/', function *(ctx, next) {...});
+ * posts.get('/:pid', function *(ctx, next) {...});
  * forums.use('/forums/:fid/posts', posts.routes(), posts.allowedMethods());
  *
  * // responds to "/forums/123/posts" and "/forums/123/posts/123"
@@ -153,8 +156,8 @@ function Router(opts) {
  * Named route parameters are captured and added to `ctx.params`.
  *
  * ```javascript
- * router.get('/:category/:title', function *(next) {
- *   console.log(this.params);
+ * router.get('/:category/:title', function (ctx, next) {
+ *   console.log(ctx.params);
  *   // => { category: 'programming', title: 'how-to-node' }
  * });
  * ```
@@ -203,6 +206,9 @@ Router.prototype.del = Router.prototype['delete'];
  *
  * // use middleware only with given path
  * router.use('/users', userAuth());
+ *
+ * // or with an array of paths
+ * // router.use(['/users', '/admin'], userAuth());
  *
  * app.use(router.routes());
  * ```
@@ -295,43 +301,31 @@ Router.prototype.prefix = function (prefix) {
 Router.prototype.routes = Router.prototype.middleware = function () {
   var router = this;
 
-  var dispatch = function *dispatch(next) {
-    debug('%s %s', this.method, this.path);
+  var dispatch = function dispatch(ctx, next) {
+    debug('%s %s', ctx.method, ctx.path);
 
-    var path = router.opts.routerPath || this.routerPath || this.path;
-    var matched = router.match(path, this.method);
-    var layer, i, ii;
+    var path = router.opts.routerPath || ctx.routerPath || ctx.path;
+    var matched = router.match(path, ctx.method);
+    var layerChain, layer, i;
 
-    if (this.matched) {
-      this.matched.push.apply(this.matched, matched.path);
+    if (ctx.matched) {
+      ctx.matched.push.apply(ctx.matched, matched.path);
     } else {
-      this.matched = matched.path;
+      ctx.matched = matched.path;
     }
 
-    if (matched.pathAndMethod.length) {
-      i = matched.pathAndMethod.length;
-      while (matched.route && i--) {
-        layer = matched.pathAndMethod[i];
-        ii = layer.stack.length;
-        this.captures = layer.captures(path, this.captures);
-        this.params = layer.params(path, this.captures, this.params);
-        debug('dispatch %s %s', layer.path, layer.regexp);
+    if (!matched.route) return next();
 
-        while (ii--) {
-          if (layer.stack[ii].constructor.name === 'GeneratorFunction') {
-            next = layer.stack[ii].call(this, next);
-          } else {
-            next = Promise.resolve(layer.stack[ii].call(this, next));
-          }
-        }
-      }
-    }
+    layerChain = matched.pathAndMethod.reduce(function(memo, layer) {
+      memo.push(function(ctx, next) {
+        ctx.captures = layer.captures(path, ctx.captures);
+        ctx.params = layer.params(path, ctx.captures, ctx.params);
+        return next();
+      });
+      return memo.concat(layer.stack);
+    }, []);
 
-    if (typeof next.next === 'function') {
-      yield *next;
-    } else {
-      yield next;
-    }
+    return compose(layerChain)(ctx, next);
   };
 
   dispatch.router = this;
@@ -363,40 +357,40 @@ Router.prototype.allowedMethods = function (options) {
   options = options || {};
   var implemented = this.methods;
 
-  return function *allowedMethods(next) {
-    yield *next;
+  return function allowedMethods(ctx, next) {
+    return next().then(function() {
+      var allowed = {};
 
-    var allowed = {};
-
-    if (!this.status || this.status === 404) {
-      this.matched.forEach(function (route) {
-        route.methods.forEach(function (method) {
-          allowed[method] = method;
+      if (!ctx.status || ctx.status === 404) {
+        ctx.matched.forEach(function (route) {
+          route.methods.forEach(function (method) {
+            allowed[method] = method;
+          });
         });
-      });
 
-      var allowedArr = Object.keys(allowed);
+        var allowedArr = Object.keys(allowed);
 
-      if (!~implemented.indexOf(this.method)) {
-        if (options.throw) {
-          throw new HttpError.NotImplemented();
-        } else {
-          this.status = 501;
-          this.set('Allow', allowedArr);
-        }
-      } else if (allowedArr.length) {
-        if (this.method === 'OPTIONS') {
-          this.status = 204;
-        } else if (!allowed[this.method]) {
+        if (!~implemented.indexOf(ctx.method)) {
           if (options.throw) {
-            throw new HttpError.MethodNotAllowed();
+            throw new HttpError.NotImplemented();
           } else {
-            this.status = 405;
+            ctx.status = 501;
+            ctx.set('Allow', allowedArr);
           }
+        } else if (allowedArr.length) {
+          if (ctx.method === 'OPTIONS') {
+            ctx.status = 204;
+          } else if (!allowed[ctx.method]) {
+            if (options.throw) {
+              throw new HttpError.MethodNotAllowed();
+            } else {
+              ctx.status = 405;
+            }
+          }
+          ctx.set('Allow', allowedArr);
         }
-        this.set('Allow', allowedArr);
       }
-    }
+    });
   };
 };
 
@@ -441,9 +435,9 @@ Router.prototype.all = function (name, path, middleware) {
  * This is equivalent to:
  *
  * ```javascript
- * router.all('/login', function *() {
- *   this.redirect('/sign-in');
- *   this.status = 301;
+ * router.all('/login', function (ctx) {
+ *   ctx.redirect('/sign-in');
+ *   ctx.status = 301;
  * });
  * ```
  *
@@ -464,9 +458,9 @@ Router.prototype.redirect = function (source, destination, code) {
     destination = this.url(destination);
   }
 
-  return this.all(source, function *() {
-    this.redirect(destination);
-    this.status = code || 301;
+  return this.all(source, function (ctx) {
+    ctx.redirect(destination);
+    ctx.status = code || 301;
   });
 };
 
@@ -563,7 +557,7 @@ Router.prototype.route = function (name) {
  * arguments (for regular expression routes).
  *
  * ```javascript
- * router.get('user', '/users/:id', function *(next) {
+ * router.get('user', '/users/:id', function (ctx, next) {
  *  // ...
  * });
  *
@@ -635,16 +629,18 @@ Router.prototype.match = function (path, method) {
  *
  * ```javascript
  * router
- *   .param('user', function *(id, next) {
- *     this.user = users[id];
- *     if (!this.user) return this.status = 404;
- *     yield next;
+ *   .param('user', function (id, ctx, next) {
+ *     ctx.user = users[id];
+ *     if (!ctx.user) return ctx.status = 404;
+ *     return next();
  *   })
- *   .get('/users/:user', function *(next) {
- *     this.body = this.user;
+ *   .get('/users/:user', function (ctx) {
+ *     ctx.body = ctx.user;
  *   })
- *   .get('/users/:user/friends', function *(next) {
- *     this.body = yield this.user.getFriends();
+ *   .get('/users/:user/friends', function (ctx) {
+ *     return ctx.user.getFriends().then(function(friends) {
+ *       ctx.body = friends;
+ *     });
  *   })
  *   // /users/3 => {"id": 3, "name": "Alex"}
  *   // /users/3/friends => [{"id": 4, "name": "TJ"}]

--- a/package.json
+++ b/package.json
@@ -20,15 +20,16 @@
   "dependencies": {
     "debug": "^2.2.0",
     "http-errors": "^1.3.1",
+    "koa-compose": "^3.0.0",
     "methods": "^1.0.1",
     "path-to-regexp": "^1.1.1"
   },
   "devDependencies": {
+    "expect.js": "^0.3.1",
     "gulp": "^3.8.11",
     "gulp-mocha": "^2.0.0",
     "jsdoc-to-markdown": "^1.1.1",
-    "expect.js": "^0.3.1",
-    "koa": "^0.20.0",
+    "koa": "^2.0.0-alpha.2",
     "mocha": "^2.0.1",
     "should": "^6.0.3",
     "supertest": "^1.0.1"

--- a/test/lib/layer.js
+++ b/test/lib/layer.js
@@ -2,7 +2,7 @@
  * Route tests
  */
 
-var koa = require('koa')
+var Koa = require('koa')
   , http = require('http')
   , request = require('supertest')
   , Router = require('../../lib/router')
@@ -11,18 +11,18 @@ var koa = require('koa')
 
 describe('Layer', function() {
   it('composes multiple callbacks/middlware', function(done) {
-    var app = koa();
+    var app = new Koa();
     var router = new Router();
     app.use(router.routes());
     router.get(
       '/:category/:title',
-      function *(next) {
-        this.status = 500;
-        yield next;
+      function (ctx, next) {
+        ctx.status = 500;
+        return next();
       },
-      function *(next) {
-        this.status = 204;
-        yield next;
+      function (ctx, next) {
+        ctx.status = 204;
+        return next();
       }
     );
     request(http.createServer(app.callback()))
@@ -36,15 +36,15 @@ describe('Layer', function() {
 
   describe('Layer#match()', function() {
     it('captures URL path parameters', function(done) {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
       app.use(router.routes());
-      router.get('/:category/:title', function *(next) {
-        this.should.have.property('params');
-        this.params.should.be.type('object');
-        this.params.should.have.property('category', 'match');
-        this.params.should.have.property('title', 'this');
-        this.status = 204;
+      router.get('/:category/:title', function (ctx) {
+        ctx.should.have.property('params');
+        ctx.params.should.be.type('object');
+        ctx.params.should.have.property('category', 'match');
+        ctx.params.should.have.property('title', 'this');
+        ctx.status = 204;
       });
       request(http.createServer(app.callback()))
       .get('/match/this')
@@ -56,15 +56,15 @@ describe('Layer', function() {
     });
 
     it('return orginal path parameters when decodeURIComponent throw error', function(done) {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
       app.use(router.routes());
-      router.get('/:category/:title', function *(next) {
-        this.should.have.property('params');
-        this.params.should.be.type('object');
-        this.params.should.have.property('category', '100%');
-        this.params.should.have.property('title', '101%');
-        this.status = 204;
+      router.get('/:category/:title', function (ctx) {
+        ctx.should.have.property('params');
+        ctx.params.should.be.type('object');
+        ctx.params.should.have.property('category', '100%');
+        ctx.params.should.have.property('title', '101%');
+        ctx.status = 204;
       });
       request(http.createServer(app.callback()))
       .get('/100%/101%')
@@ -73,19 +73,19 @@ describe('Layer', function() {
     });
 
     it('populates ctx.captures with regexp captures', function(done) {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
       app.use(router.routes());
-      router.get(/^\/api\/([^\/]+)\/?/i, function *(next) {
-        this.should.have.property('captures');
-        this.captures.should.be.instanceOf(Array);
-        this.captures.should.have.property(0, '1');
-        yield next;
-      }, function *(next) {
-        this.should.have.property('captures');
-        this.captures.should.be.instanceOf(Array);
-        this.captures.should.have.property(0, '1');
-        this.status = 204;
+      router.get(/^\/api\/([^\/]+)\/?/i, function (ctx, next) {
+        ctx.should.have.property('captures');
+        ctx.captures.should.be.instanceOf(Array);
+        ctx.captures.should.have.property(0, '1');
+        return next();
+      }, function (ctx) {
+        ctx.should.have.property('captures');
+        ctx.captures.should.be.instanceOf(Array);
+        ctx.captures.should.have.property(0, '1');
+        ctx.status = 204;
       });
       request(http.createServer(app.callback()))
       .get('/api/1')
@@ -97,19 +97,19 @@ describe('Layer', function() {
     });
 
     it('return orginal ctx.captures when decodeURIComponent throw error', function(done) {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
       app.use(router.routes());
-      router.get(/^\/api\/([^\/]+)\/?/i, function *(next) {
-        this.should.have.property('captures');
-        this.captures.should.be.type('object');
-        this.captures.should.have.property(0, '101%');
-        yield next;
-      }, function *(next) {
-        this.should.have.property('captures');
-        this.captures.should.be.type('object');
-        this.captures.should.have.property(0, '101%');
-        this.status = 204;
+      router.get(/^\/api\/([^\/]+)\/?/i, function (ctx, next) {
+        ctx.should.have.property('captures');
+        ctx.captures.should.be.type('object');
+        ctx.captures.should.have.property(0, '101%');
+        return next();
+      }, function (ctx, next) {
+        ctx.should.have.property('captures');
+        ctx.captures.should.be.type('object');
+        ctx.captures.should.have.property(0, '101%');
+        ctx.status = 204;
       });
       request(http.createServer(app.callback()))
       .get('/api/101%')
@@ -121,19 +121,19 @@ describe('Layer', function() {
     });
 
     it('populates ctx.captures with regexp captures include undefiend', function(done) {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
       app.use(router.routes());
-      router.get(/^\/api(\/.+)?/i, function *(next) {
-        this.should.have.property('captures');
-        this.captures.should.be.type('object');
-        this.captures.should.have.property(0, undefined);
-        yield next;
-      }, function *(next) {
-        this.should.have.property('captures');
-        this.captures.should.be.type('object');
-        this.captures.should.have.property(0, undefined);
-        this.status = 204;
+      router.get(/^\/api(\/.+)?/i, function (ctx, next) {
+        ctx.should.have.property('captures');
+        ctx.captures.should.be.type('object');
+        ctx.captures.should.have.property(0, undefined);
+        return next();
+      }, function (ctx) {
+        ctx.should.have.property('captures');
+        ctx.captures.should.be.type('object');
+        ctx.captures.should.have.property(0, undefined);
+        ctx.status = 204;
       });
       request(http.createServer(app.callback()))
       .get('/api')
@@ -145,7 +145,7 @@ describe('Layer', function() {
     });
 
     it('should throw friendly error message when handle not exists', function() {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
       app.use(router.routes());
       var notexistHandle = undefined;
@@ -165,15 +165,15 @@ describe('Layer', function() {
 
   describe('Layer#param()', function() {
     it('composes middleware for param fn', function(done) {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
-      var route = new Layer('/users/:user', ['GET'], [function *(next) {
-        this.body = this.user;
+      var route = new Layer('/users/:user', ['GET'], [function (ctx) {
+        ctx.body = ctx.user;
       }]);
-      route.param('user', function *(id, next) {
-        this.user = { name: 'alex' };
-        if (!id) return this.status = 404;
-        yield next;
+      route.param('user', function (id, ctx, next) {
+        ctx.user = { name: 'alex' };
+        if (!id) return ctx.status = 404;
+        return next();
       });
       router.stack.push(route);
       app.use(router.middleware());
@@ -189,20 +189,20 @@ describe('Layer', function() {
     });
 
     it('ignores params which are not matched', function(done) {
-      var app = koa();
+      var app = new Koa();
       var router = new Router();
-      var route = new Layer('/users/:user', ['GET'], [function *(next) {
-        this.body = this.user;
+      var route = new Layer('/users/:user', ['GET'], [function (ctx) {
+        ctx.body = ctx.user;
       }]);
-      route.param('user', function *(id, next) {
-        this.user = { name: 'alex' };
-        if (!id) return this.status = 404;
-        yield next;
+      route.param('user', function (id, ctx, next) {
+        ctx.user = { name: 'alex' };
+        if (!id) return ctx.status = 404;
+        return next();
       });
-      route.param('title', function *(id, next) {
-        this.user = { name: 'mark' };
-        if (!id) return this.status = 404;
-        yield next;
+      route.param('title', function (id, ctx, next) {
+        ctx.user = { name: 'mark' };
+        if (!id) return ctx.status = 404;
+        return next();
       });
       router.stack.push(route);
       app.use(router.middleware());
@@ -220,7 +220,7 @@ describe('Layer', function() {
 
   describe('Layer#url()', function() {
     it('generates route URL', function() {
-      var route = new Layer('/:category/:title', ['get'], [function* () {}], 'books');
+      var route = new Layer('/:category/:title', ['get'], [function () {}], 'books');
       var url = route.url({ category: 'programming', title: 'how-to-node' });
       url.should.equal('/programming/how-to-node');
       url = route.url('programming', 'how-to-node');
@@ -228,7 +228,7 @@ describe('Layer', function() {
     });
 
     it('escapes using encodeURIComponent()', function() {
-      var route = new Layer('/:category/:title', ['get'], [function *() {}], 'books');
+      var route = new Layer('/:category/:title', ['get'], [function () {}], 'books');
       var url = route.url({ category: 'programming', title: 'how to node' });
       url.should.equal('/programming/how%20to%20node');
     });


### PR DESCRIPTION
Opening this for discussion and thoughts:

I was messing with Koa 2 alpha 2 and needed a router — breaking changes around passing `ctx` as an argument yields `koa-router` unusable right now. There's another project [`ko66`](https://github.com/menems/koa-66) that seems to be a similar project that's been setup for Koa 2 support, but I'd like to see this lib grow and I'm sure others would as well.

This PR updates all middleware to the Promise-based Koa 2 async pattern. It does not use `async/await`notation or transpiling, which I could see being an options for this lib as well. For simplicity's sake, everything `GeneratorFunction` was changed to a function with promise-based flow, all middleware functions were updates to the `(ctx, next)` signature and `ctx` is now used in place of `this` when modifying the middleware context. 

Additionally, `koa-compose` was added as a dependency to drive layer middleware stacks. I think this is a better choice than invoking the layer chain of middleware functions by hand (ordered). Since `koa-compose` drives the actual koa middleware execution, there's likely going to be fewer issues when koa middleware api changes, as the compose lib can simply be updated. This also allows for exact same async flow in normal koa middleware due to the same dispatch function driving https://github.com/koajs/compose/blob/master/index.js#L31

By using Koa 2, >= node 4 would be *required*
> (Koa requires node v4.0.0 or higher for (partial) ES2015 support.)

I have not updated the `history.md` with these notes.

### Updates:

* update koa dependency to alpha2
* add koa-compose dependency for layer stack composition
* update middleware signature to `(ctx, next)`
* update param middleware signature to `(param, ctx, next)`
* remove all generator functions and gen type checks
* update all specs for promise-based usage
* updates examples / comments / docs