### PR TITLE
Nonexistent parameters passed when matching/dispatching routes

### DIFF
--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -782,6 +782,34 @@ describe('Router', function() {
             });
         });
     });
+
+    it('resolves non-parameterized routes without attached parameters', function(done) {
+      var app = koa();
+      var router = new Router();
+
+      router.get('/notparameter', function *(next) {
+        this.body = {
+          param: this.params.parameter,
+        };
+      });
+
+      router.get('/:parameter', function *(next) {
+        this.body = {
+          param: this.params.parameter,
+        };
+      });
+
+      app.use(router.routes());
+      request(http.createServer(app.callback()))
+        .get('/notparameter')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+
+          expect(res.body.param).to.equal(undefined);
+          done();
+        });
+    });
   });
 
   describe('Router#use()', function (done) {


### PR DESCRIPTION
Because of changes introduced in 883c1aff (5.2.0+), in some cases, routes without any parameters receive incorrect parameter values regardless.

Example:
```
router.get('/notparameter', function *(next) {
  // Problem: this.params.param shouldn't exist, but does.
});

router.get('/:param', function *(next) {
  // this.params.param should exist. No problem here.
});
```
It's because of the way the code iterates when matching routes - caching captures and params from the previous iteration. I wasn't sure why it did that, so I created a failing test case instead. Hope it helps.