### PR TITLE
Fix reference to ctx.method in router.js

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -387,7 +387,7 @@ Router.prototype.allowedMethods = function (options) {
           if (ctx.method === 'OPTIONS') {
             ctx.status = 204;
             ctx.set('Allow', allowedArr);
-          } else if (!allowed[this.method]) {
+          } else if (!allowed[ctx.method]) {
             if (options.throw) {
               var notAllowedThrowable;
               if (typeof options.methodNotAllowed === 'function') {


### PR DESCRIPTION
I believe this.method is from an older version of Koa?
It should be ctx.method, this.method is undefined.