### PR TITLE
Ensure prefix is not yet present

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -205,7 +205,7 @@ Layer.prototype.param = function (param, fn) {
  */
 
 Layer.prototype.setPrefix = function (prefix) {
-  if (this.path) {
+  if (this.path && this.path.indexOf(prefix) !== 0) {
     this.path = prefix + this.path;
     this.paramNames = [];
     this.regexp = pathToRegExp(this.path, this.paramNames, this.opts);


### PR DESCRIPTION
When executing tests & reconstructing routers for every test the layers seem to be cached & the prefix is added multiple time.

E.g. 

``` 
var router = new Router();
router.use('/nested', (new Router().get('/example', function*() {}).routes() );
app.use(router.routes());
```

generates for the # of test runs:

```
1. /nested/example
2. /nested/nested/example
3. /nested/nested/nested/example
# etc
```

This patch solves this issue, even though it does not solve it at the root. 