### PR TITLE
add _matchedRoute to context

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -310,6 +310,10 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
     if (matched.pathAndMethod.length) {
       i = matched.pathAndMethod.length;
+      
+      var mostSpecificPath = matched.pathAndMethod[matched.pathAndMethod.length - 1].path
+      this._matchedRoute = mostSpecificPath
+
       while (matched.route && i--) {
         layer = matched.pathAndMethod[i];
         ii = layer.stack.length;

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1260,6 +1260,35 @@ describe('Router', function() {
         done();
       });
     });
+
+    it('places a `_matchedRoute` value on context', function(done) {
+      var app = koa();
+      var router = new Router();
+      var middleware = function *(next) {
+        expect(this._matchedRoute).to.be('/users/:id')
+        yield next;
+      };
+
+      router.use(middleware);
+      router.get('/users/:id', function *() {
+        expect(this._matchedRoute).to.be('/users/:id')
+        should.exist(this.params.id);
+        this.body = { hello: 'world' };
+      });
+
+      var routerMiddleware = router.routes();
+
+      request(http.createServer(
+        app
+          .use(routerMiddleware)
+          .callback()))
+      .get('/users/1')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        done();
+      });
+    });
   });
 
   describe('If no HEAD method, default to GET', function() {


### PR DESCRIPTION
Expose the route that matched the current request on context. This is useful for monitoring and analytics, and enables you to do something like the following:

```javascript
function* routeMetrics(next) {
  var start = Date.now()
  yield next
  var duration = Date.now() - start
  // send a metric
  statsd.timing(this._matchedRoute, duration)
  // this.matchedRoute would be the string of the matched route, so '/foo/:id/:type/' in this case
}
```

This will send a count of the number of times a specific route is hit, even if the route has dynamic parts.

I'm happy to tweak this, change the name, or add more tests if you are ok with this basic idea.

I believe this fixes #223.