### PR TITLE
Add support for conditional routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ router.get(
 );
 ```
 
-### Nested routers
+#### Nested routers
 
 Nesting routers is supported:
 
@@ -169,6 +169,23 @@ router.get('/:category/:title', function *(next) {
   console.log(this.params);
   // => { category: 'programming', title: 'how-to-node' }
 });
+```
+
+#### Conditional routes
+
+Routes can optionally have conditions:
+
+```javascript
+router.get(   
+  '/posts',
+  function *(next) {
+    this.body = yield getPostsByTag(this.query['tag']);
+  }, {
+    condition: function () {
+      return this.query['tag'];
+    }
+  }
+);
 ```
 
 **Kind**: instance property of <code>[Router](#exp_module_koa-router--Router)</code>

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -23,6 +23,7 @@ function Layer(path, methods, middleware, opts) {
   this.methods = [];
   this.paramNames = [];
   this.stack = Array.isArray(middleware) ? middleware : [middleware];
+  this.condition = this.opts.condition;
 
   methods.forEach(function(method) {
     var l = this.methods.push(method.toUpperCase());

--- a/lib/router.js
+++ b/lib/router.js
@@ -169,20 +169,22 @@ function Router(opts) {
  */
 
 methods.forEach(function (method) {
-  Router.prototype[method] = function (name, path, middleware) {
-    var middleware;
+  Router.prototype[method] = function (name, path, middleware, opts) {
+    var rest;
+    var opts;
 
     if (typeof path === 'string' || path instanceof RegExp) {
-      middleware = Array.prototype.slice.call(arguments, 2);
+      rest = Array.prototype.slice.call(arguments, 2);
     } else {
-      middleware = Array.prototype.slice.call(arguments, 1);
+      rest = Array.prototype.slice.call(arguments, 1);
       path = name;
       name = null;
     }
 
-    this.register(path, [method], middleware, {
-      name: name
-    });
+    opts = typeof rest[rest.length - 1] === 'object' ? rest.pop() : {};
+    opts.name = name;
+
+    this.register(path, [method], rest, opts);
 
     return this;
   };
@@ -311,22 +313,25 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
     if (matched.pathAndMethod.length) {
       i = matched.pathAndMethod.length;
-      
-      var mostSpecificPath = matched.pathAndMethod[matched.pathAndMethod.length - 1].path
-      this._matchedRoute = mostSpecificPath
 
       while (matched.route && i--) {
         layer = matched.pathAndMethod[i];
-        ii = layer.stack.length;
-        this.captures = layer.captures(path, this.captures);
-        this.params = layer.params(path, this.captures, this.params);
-        debug('dispatch %s %s', layer.path, layer.regexp);
+        if (!layer.condition || layer.condition.call(this)) {
+          if (!this._matchedRoute) {
+            this._matchedRoute = layer.path;
+          }
 
-        while (ii--) {
-          if (layer.stack[ii].constructor.name === 'GeneratorFunction') {
-            next = layer.stack[ii].call(this, next);
-          } else {
-            next = Promise.resolve(layer.stack[ii].call(this, next));
+          ii = layer.stack.length;
+          this.captures = layer.captures(path, this.captures);
+          this.params = layer.params(path, this.captures, this.params);
+          debug('dispatch %s %s', layer.path, layer.regexp);
+
+          while (ii--) {
+            if (layer.stack[ii].constructor.name === 'GeneratorFunction') {
+              next = layer.stack[ii].call(this, next);
+            } else {
+              next = Promise.resolve(layer.stack[ii].call(this, next));
+            }
           }
         }
       }
@@ -511,6 +516,7 @@ Router.prototype.register = function (path, methods, middleware, opts) {
     sensitive: opts.sensitive || this.opts.sensitive || false,
     strict: opts.strict || this.opts.strict || false,
     prefix: opts.prefix || this.opts.prefix || "",
+    condition: opts.condition || this.opts.condition,
   });
 
   if (this.opts.prefix) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -120,7 +120,7 @@ function Router(opts) {
  * );
  * ```
  *
- * ### Nested routers
+ * #### Nested routers
  *
  * Nesting routers is supported:
  *
@@ -158,6 +158,23 @@ function Router(opts) {
  *   console.log(this.params);
  *   // => { category: 'programming', title: 'how-to-node' }
  * });
+ * ```
+ *
+ * #### Conditional routes
+ *
+ * Routes can optionally have conditions:
+ *
+ * ```javascript
+ * router.get(
+ *   '/posts',
+ *   function *(next) {
+ *     this.body = yield getPostsByTag(this.query['tag']);
+ *   }, {
+ *     condition: function () {
+ *       return this.query['tag'];
+ *     }
+ *   }
+ * );
  * ```
  *
  * @name get|put|post|patch|delete

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -818,7 +818,7 @@ describe('Router', function() {
 
     router.get('/foo', function *(next) {
       this.body = this.body || {};
-      this.body.foo = bar;
+      this.body.foo = 'bar';
       yield next;
     }, {
       condition: function() {


### PR DESCRIPTION
This PR adds support for conditional routes:

```javascript
router.get(   
  '/posts',
  function *(next) {
    this.body = yield getPostsByTag(this.query['tag']);
  }, {
    condition: function () {
      return this.query['tag'];
    }
  }
);
```