### PR TITLE
fix allowedMethods function return

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -371,7 +371,7 @@ Router.prototype.allowedMethods = function (options) {
   var implemented = this.methods;
 
   return function *allowedMethods(next) {
-    yield *next;
+    var result = yield *next;
 
     var allowed = {};
 
@@ -416,6 +416,8 @@ Router.prototype.allowedMethods = function (options) {
         this.set('Allow', allowedArr);
       }
     }
+
+    return result;
   };
 };
 


### PR DESCRIPTION
I think the middleware function named allowedMethods should return the result.
It must return the result of 'yield *next', so that the next middleware function can get the value.

Sorry for my poor English.
Wish you work happily.