### PR TITLE
Fix bug where param handlers were run out of order

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -170,28 +170,23 @@ Layer.prototype.param = function (param, fn) {
   };
   middleware.param = param;
 
-  params.forEach(function (p, i) {
-    var prev = params[i - 1];
-
-    if (param === p.name) {
-      // insert param middleware in order params appear in path
-      if (prev) {
-        if (!stack.some(function (m, i) {
-          if (m.param === prev.name) {
-            return stack.splice(i + 1, 0, middleware);
-          }
-        })) {
-          stack.some(function (m, i) {
-            if (!m.param) {
-              return stack.splice(i, 0, middleware);
-            }
-          });
-        }
-      } else {
-        stack.unshift(middleware);
-      }
-    }
+  var names = params.map(function (p) {
+    return p.name;
   });
+
+  var x = names.indexOf(param);
+  if (x > -1) {
+    // iterate through the stack, to figure out where to place the handler fn
+    stack.some(function (fn, i) {
+      // param handlers are always first, so when we find an fn w/o a param property, stop here
+      // if the param handler at this part of the stack comes after the one we are adding, stop here
+      if (!fn.param || names.indexOf(fn.param) > x) {
+        // inject this param handler right before the current item
+        stack.splice(i, 0, middleware);
+        return true; // then break the loop
+      }
+    });
+  }
 
   return this;
 };

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -178,7 +178,7 @@ Layer.prototype.param = function (param, fn) {
       if (prev) {
         if (!stack.some(function (m, i) {
           if (m.param === prev.name) {
-            return stack.splice(i, 0, middleware);
+            return stack.splice(i + 1, 0, middleware);
           }
         })) {
           stack.some(function (m, i) {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1124,15 +1124,16 @@ describe('Router', function() {
       });
     });
 
-    it('runs many parameter middleware in order of URL appearance', function(done) {
+    it('runs parameter middleware in order of URL appearance even when added in random order', function(done) {
       var app = koa();
       var router = new Router();
       router
+        // intentional random order
         .param('a', function *(id, next) {
           this.state.loaded = [ id ];
           yield next;
         })
-        .param('b', function *(id, next) {
+        .param('d', function *(id, next) {
           this.state.loaded.push(id);
           yield next;
         })
@@ -1140,7 +1141,7 @@ describe('Router', function() {
           this.state.loaded.push(id);
           yield next;
         })
-        .param('d', function *(id, next) {
+        .param('b', function *(id, next) {
           this.state.loaded.push(id);
           yield next;
         })


### PR DESCRIPTION
This fixes #237 by adjusting the way that param handlers are injected into the stack. Currently, the params handlers are added in the order in which you defined them, rather than the order they are defined in the URL.

I've added a few tests cases here to demonstrate the problem, as well as made the necessary changes to fix it. (all other tests are still passing)

Apologies for the weird PR, I actually started on this fix a couple of months ago, but then got sidetracked after a solution didn't come to mind easily. I picked it up again yesterday, and finally came up with something elegant. :)