### PR TITLE
fix incorrect params with router.use(fn)

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -92,6 +92,7 @@ Layer.prototype.params = function (path, captures, existingParams) {
  */
 
 Layer.prototype.captures = function (path) {
+  if (this.opts.ignoreCaptures) return [];
   return path.match(this.regexp).slice(1);
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -255,7 +255,8 @@ Router.prototype.use = function () {
 
   if (middleware.length) {
     router.register(path || '(.*)', [], middleware, {
-      end: false
+      end: false,
+      ignoreCaptures: !path
     });
   }
 
@@ -311,7 +312,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
     if (matched.pathAndMethod.length) {
       i = matched.pathAndMethod.length;
-      
+
       var mostSpecificPath = matched.pathAndMethod[matched.pathAndMethod.length - 1].path
       this._matchedRoute = mostSpecificPath
 
@@ -511,6 +512,7 @@ Router.prototype.register = function (path, methods, middleware, opts) {
     sensitive: opts.sensitive || this.opts.sensitive || false,
     strict: opts.strict || this.opts.strict || false,
     prefix: opts.prefix || this.opts.prefix || "",
+    ignoreCaptures: opts.ignoreCaptures
   });
 
   if (this.opts.prefix) {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -945,6 +945,31 @@ describe('Router', function() {
             });
         });
     });
+
+    it('without path, does not set params.0 to the matched path - gh-247', function (done) {
+      var app = koa();
+      var router = new Router();
+
+      router.use(function *(next) {
+        yield next;
+      });
+
+      router.get('/foo/:id', function *(next) {
+        this.body = this.params;
+      });
+
+      app.use(router.routes());
+      request(http.createServer(app.callback()))
+        .get('/foo/815')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+
+          expect(res.body).to.have.property('id', '815');
+          expect(res.body).to.not.have.property('0');
+          done();
+        });
+    });
   });
 
   describe('Router#register()', function() {
@@ -1352,6 +1377,35 @@ describe('Router', function() {
       expect(route.paramNames).to.have.length(2);
       expect(route.paramNames[0]).to.have.property('name', 'thing_id');
       expect(route.paramNames[1]).to.have.property('name', 'id');
+    });
+
+    describe('when used with .use(fn) - gh-247', function () {
+      it('does not set params.0 to the matched path', function (done) {
+        var app = koa();
+        var router = new Router();
+
+        router.use(function *(next) {
+          yield next;
+        });
+
+        router.get('/foo/:id', function *() {
+          this.body = this.params;
+        });
+
+        router.prefix('/things');
+
+        app.use(router.routes());
+        request(http.createServer(app.callback()))
+          .get('/things/foo/108')
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err);
+
+            expect(res.body).to.have.property('id', '108');
+            expect(res.body).to.not.have.property('0');
+            done();
+          });
+      });
     });
 
     describe('with trailing slash', testPrefix('/admin/'));


### PR DESCRIPTION
This pull request fixes the extra params bug (#247) which occurs when middleware is `use`d without a path. Before this PR, `this.params[0]` is incorrectly set to the path of the matched route. After this PR, only the named parameters are set.
