### PR TITLE
fix incorrect params with router.use(fn) (koa2)

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -92,6 +92,7 @@ Layer.prototype.params = function (path, captures, existingParams) {
  */
 
 Layer.prototype.captures = function (path) {
+  if (this.opts.ignoreCaptures) return [];
   return path.match(this.regexp).slice(1);
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -240,7 +240,8 @@ Router.prototype.use = function () {
     return this;
   }
 
-  if (typeof middleware[0] === 'string') {
+  var hasPath = typeof middleware[0] === 'string';
+  if (hasPath) {
     path = middleware.shift();
   }
 
@@ -258,7 +259,7 @@ Router.prototype.use = function () {
         });
       }
     } else {
-      router.register(path, [], m, { end: false });
+      router.register(path, [], m, { end: false, ignoreCaptures: !hasPath });
     }
   });
 
@@ -509,6 +510,7 @@ Router.prototype.register = function (path, methods, middleware, opts) {
     sensitive: opts.sensitive || this.opts.sensitive || false,
     strict: opts.strict || this.opts.strict || false,
     prefix: opts.prefix || this.opts.prefix || "",
+    ignoreCaptures: opts.ignoreCaptures
   });
 
   if (this.opts.prefix) {


### PR DESCRIPTION
fixes #247 for koa2 (master branch)

see #287 