### PR TITLE
support koa-resource-router

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -637,7 +637,8 @@ Router.prototype.match = function (path, method) {
 
       if (layer.methods.length === 0 || ~layer.methods.indexOf(method)) {
         matched.pathAndMethod.push(layer);
-        if (layer.methods.length) matched.route = true;
+        // Notes: support for koa-resource-router 
+        matched.route = true;
       }
     }
   }


### PR DESCRIPTION
This fix is for koa-resource-router,  current version is blocked all koa resource router middleware.
So pls merge this change to help other guys if they need koa-resource-router too.
