### PR TITLE
add `_matchedRouteName` to context

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -316,10 +316,14 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
     if (!matched.route) return next();
 
-    var mostSpecificPath = matched.pathAndMethod[matched.pathAndMethod.length - 1].path;
-    ctx._matchedRoute = mostSpecificPath;
+    var matchedLayers = matched.pathAndMethod
+    var mostSpecificLayer = matchedLayers[matchedLayers.length - 1]
+    ctx._matchedRoute = mostSpecificLayer.path;
+    if (mostSpecificLayer.name) {
+      ctx._matchedRouteName = mostSpecificLayer.name;
+    }
 
-    layerChain = matched.pathAndMethod.reduce(function(memo, layer) {
+    layerChain = matchedLayers.reduce(function(memo, layer) {
       memo.push(function(ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = layer.params(path, ctx.captures, ctx.params);

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1379,6 +1379,42 @@ describe('Router', function () {
         done();
       });
     });
+
+    it('places a `_matchedRouteName` value on the context for a named route', function(done) {
+      var app = new Koa();
+      var router = new Router();
+
+      router.get('users#show', '/users/:id', function (ctx, next) {
+        expect(ctx._matchedRouteName).to.be('users#show')
+        ctx.status = 200
+      });
+
+      request(http.createServer(app.use(router.routes()).callback()))
+      .get('/users/1')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+    it('does not place a `_matchedRouteName` value on the context for unnamed routes', function(done) {
+      var app = new Koa();
+      var router = new Router();
+
+      router.get('/users/:id', function (ctx, next) {
+        expect(ctx._matchedRouteName).to.be(undefined)
+        ctx.status = 200
+      });
+
+      request(http.createServer(app.use(router.routes()).callback()))
+      .get('/users/1')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        done();
+      });
+    });
   });
 
   describe('If no HEAD method, default to GET', function () {


### PR DESCRIPTION
sometimes route paths can be very long & convoluted (legacy apis), exposing the layer
name provides a saner alternative for analytics

this is an extension to #236 

/cc @alexmingoia @jergason