### PR TITLE
fix promise middleware

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -9,6 +9,7 @@ var debug = require('debug')('koa-router');
 var HttpError = require('http-errors');
 var methods = require('methods');
 var Layer = require('./layer');
+var co = require('co');
 
 /**
  * @module koa-router
@@ -322,20 +323,15 @@ Router.prototype.routes = Router.prototype.middleware = function () {
         debug('dispatch %s %s', layer.path, layer.regexp);
 
         while (ii--) {
-          if (layer.stack[ii].constructor.name === 'GeneratorFunction') {
-            next = layer.stack[ii].call(this, next);
-          } else {
-            next = Promise.resolve(layer.stack[ii].call(this, next));
-          }
+          var stack = layer.stack[ii].constructor.name === 'GeneratorFunction'
+            ? layer.stack[ii]
+            : wrapAsyncToGenerator(layer.stack[ii]);
+          next = stack.call(this, next);
         }
       }
     }
 
-    if (typeof next.next === 'function') {
-      yield *next;
-    } else {
-      yield next;
-    }
+    yield *next;
   };
 
   dispatch.router = this;
@@ -698,3 +694,9 @@ Router.prototype.param = function (param, middleware) {
 Router.url = function (path, params) {
     return Layer.prototype.url.call({path: path}, params);
 };
+
+function wrapAsyncToGenerator(fn) {
+  return function* (next) {
+    yield fn.call(this, co(next));
+  }
+}

--- a/lib/router.js
+++ b/lib/router.js
@@ -697,6 +697,8 @@ Router.url = function (path, params) {
 
 function wrapAsyncToGenerator(fn) {
   return function* (next) {
-    yield fn.call(this, co(next));
+    var p = fn.call(this, co(next));
+    // only yield if return a promise
+    if (p && typeof p.then === 'function') return yield p;
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "route"
   ],
   "dependencies": {
+    "co": "^4.6.0",
     "debug": "^2.2.0",
     "http-errors": "^1.3.1",
     "methods": "^1.0.1",

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -148,6 +148,35 @@ describe('Router', function() {
       });
   });
 
+  it('supports mixed common function and generators', function (done) {
+    var app = koa();
+    app.experimental = true;
+    var router = Router();
+
+    var middleware = function* (next) {
+      this.body = [];
+      this.body.push('middleware before');
+      yield next;
+      this.body.push('middleware after');
+    };
+
+    var controller = function () {
+      this.body.push('controller');
+    };
+
+    router.get('/common', middleware, controller);
+
+    app.use(router.routes()).use(router.allowedMethods());
+    request(http.createServer(app.callback()))
+      .get('/common')
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+        expect(res.body).to.eql([ 'middleware before', 'controller', 'middleware after' ]);
+        done();
+      });
+  });
+
   it('matches middleware only if route was matched (gh-182)', function (done) {
     var app = koa();
     var router = new Router();

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -115,6 +115,39 @@ describe('Router', function() {
       });
   });
 
+  it('supports mixed promises and generators', function (done) {
+    var app = koa();
+    app.experimental = true;
+    var router = Router();
+
+    var middleware = function* (next) {
+      this.body = [];
+      this.body.push('middleware before');
+      yield next;
+      this.body.push('middleware after');
+    };
+
+    var controller = function (next) {
+      var ctx = this;
+      return new Promise(function (resolve, reject) {
+        ctx.body.push('controller');
+        resolve();
+      });
+    };
+
+    router.get('/async', middleware, controller);
+
+    app.use(router.routes()).use(router.allowedMethods());
+    request(http.createServer(app.callback()))
+      .get('/async')
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+        expect(res.body).to.eql([ 'middleware before', 'controller', 'middleware after' ]);
+        done();
+      });
+  });
+
   it('matches middleware only if route was matched (gh-182)', function (done) {
     var app = koa();
     var router = new Router();


### PR DESCRIPTION
we can't mixed promise base middleware with generator base middleware, the execute order will change.

```js
function* generatorMiddleware() {
  console.log('step 1');
  yield next;
  console.log('step 3');
}

async function asyncMiddleware() {
  console.log('step 2');
}

router.get('/', generatorMiddleware, asyncMiddleware);
```

The result will be `2 => 1 => 3` instead of `1 => 2 => 3`.

This PR fix this issue by convert async function to generator function with `co`.