### PR TITLE
Fix #292 middleware for multiple routes added, plus improved debug module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Create a new router.
 | --- | --- | --- |
 | [opts] | <code>Object</code> |  |
 | [opts.prefix] | <code>String</code> | prefix router paths |
+| [opts.useFirstMatch] | <code>Boolean</code> | if set then use only the first matching route |
 
 **Example**
 Basic usage:
@@ -171,6 +172,28 @@ var router = new Router({
 
 router.get('/', ...); // responds to "/users"
 router.get('/:id', ...); // responds to "/users/:id"
+```
+
+#### Router useFirstMatch
+
+Only use the middleware for the first matching route:
+
+```javascript
+var router = new Router({
+  useFirstMatch: true
+});
+
+router.get('/api/users/count', ...); // responds to "/users/count"
+router.get('/api/users/:id', ...); // responds to "/users/:id"
+```
+
+Default behaviour
+
+```javascript
+var router = new Router();
+
+router.get('/api/users/count', ...); // executes middleware for "/users/count"
+router.get('/api/users/:id', ...); // now executes middleware for "/users/count" and "/users/:id"
 ```
 
 #### URL parameters

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,14 +1,13 @@
-var createDebug = require('debug');
-var debug = createDebug('koa-router');
+var debug = require('debug')('koa-router');
 var pathToRegExp = require('path-to-regexp');
 
-createDebug.formatters.m = function(v) {
-  if( typeof v === 'function') {
-    return '['+(v.name?v.name:'anonymous')+']';
-  } else {
-    return JSON.stringify(v.map( function(m) { return m.name.length ? m.name : 'anonymous'}));
-  }
-}
+// createDebug.formatters.m = function(v) {
+//   if( typeof v === 'function') {
+//     return '['+(v.name?v.name:'anonymous')+']';
+//   } else {
+//     return JSON.stringify(v.map( function(m) { return m.name.length ? m.name : 'anonymous'}));
+//   }
+// }
 
 module.exports = Layer;
 

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,5 +1,14 @@
-var debug = require('debug')('koa-router');
+var createDebug = require('debug');
+var debug = createDebug('koa-router');
 var pathToRegExp = require('path-to-regexp');
+
+createDebug.formatters.m = function(v) {
+  if( typeof v === 'function') {
+    return '['+(v.name?v.name:'anonymous')+']';
+  } else {
+    return JSON.stringify(v.map( function(m) { return m.name.length ? m.name : 'anonymous'}));
+  }
+}
 
 module.exports = Layer;
 
@@ -45,7 +54,7 @@ function Layer(path, methods, middleware, opts) {
   this.path = path;
   this.regexp = pathToRegExp(path, this.paramNames, this.opts);
 
-  debug('defined route %s %s', this.methods, this.opts.prefix + this.path);
+  debug('defined route %s %s %m', this.methods, this.opts.prefix + this.path, middleware);
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,11 +5,23 @@
  * @link https://github.com/alexmingoia/koa-router
  */
 
-var debug = require('debug')('koa-router');
+var createDebug = require('debug');
+var debug = createDebug('koa-router');
 var compose = require('koa-compose');
 var HttpError = require('http-errors');
 var methods = require('methods');
 var Layer = require('./layer');
+var pathToRegExp = require('path-to-regexp');
+
+createDebug.formatters.m = function (v) {
+  if (typeof v === 'function') {
+    return '[' + (v.name ? v.name : 'anonymous') + ']';
+  } else {
+    return JSON.stringify(v.map(function (m) {
+      return m.name.length ? m.name : 'anonymous'
+    }));
+  }
+}
 
 /**
  * @module koa-router
@@ -41,21 +53,21 @@ module.exports = Router;
  * @constructor
  */
 
-function Router(opts) {
+function Router (opts) {
   if (!(this instanceof Router)) {
     return new Router(opts);
   }
 
   this.opts = opts || {};
   this.methods = this.opts.methods || [
-    'HEAD',
-    'OPTIONS',
-    'GET',
-    'PUT',
-    'PATCH',
-    'POST',
-    'DELETE'
-  ];
+      'HEAD',
+      'OPTIONS',
+      'GET',
+      'PUT',
+      'PATCH',
+      'POST',
+      'DELETE'
+    ];
 
   this.params = {};
   this.stack = [];
@@ -301,7 +313,7 @@ Router.prototype.prefix = function (prefix) {
 Router.prototype.routes = Router.prototype.middleware = function () {
   var router = this;
 
-  var dispatch = function dispatch(ctx, next) {
+  var dispatch = function dispatch (ctx, next) {
     debug('%s %s', ctx.method, ctx.path);
 
     var path = router.opts.routerPath || ctx.routerPath || ctx.path;
@@ -316,17 +328,22 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
     if (!matched.route) return next();
 
-    var mostSpecificPath = matched.pathAndMethod[matched.pathAndMethod.length - 1].path;
+    var mspIndex = router.opts.useFirstMatch ? 0 : matched.pathAndMethod.length - 1;
+    var mostSpecificPath = matched.pathAndMethod[mspIndex].path;
+
     ctx._matchedRoute = mostSpecificPath;
 
-    layerChain = matched.pathAndMethod.reduce(function(memo, layer) {
-      memo.push(function routerParams(ctx, next) {
+    var pathAndMethod = router.opts.useFirstMatch ? [matched.pathAndMethod[0]] : matched.pathAndMethod;
+    layerChain = pathAndMethod.reduce(function (memo, layer) {
+      memo.push(function routerParams (ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = layer.params(path, ctx.captures, ctx.params);
         return next();
       });
       return memo.concat(layer.stack);
     }, []);
+
+    debug('matched route %s %m', mostSpecificPath, layerChain);
 
     return compose(layerChain)(ctx, next);
   };
@@ -353,8 +370,10 @@ Router.prototype.routes = Router.prototype.middleware = function () {
  *
  * @param {Object=} options
  * @param {Boolean=} options.throw throw error instead of setting status and header
- * @param {Function=} options.notImplemented throw the returned value in place of the default NotImplemented error
- * @param {Function=} options.methodNotAllowed throw the returned value in place of the default MethodNotAllowed error
+ * @param {Function=} options.notImplemented throw the returned value in place of the default
+ *   NotImplemented error
+ * @param {Function=} options.methodNotAllowed throw the returned value in place of the default
+ *   MethodNotAllowed error
  * @returns {Function}
  */
 
@@ -362,8 +381,8 @@ Router.prototype.allowedMethods = function (options) {
   options = options || {};
   var implemented = this.methods;
 
-  return function allowedMethods(ctx, next) {
-    return next().then(function() {
+  return function allowedMethods (ctx, next) {
+    return next().then(function () {
       var allowed = {};
 
       if (!ctx.status || ctx.status === 404) {
@@ -379,7 +398,8 @@ Router.prototype.allowedMethods = function (options) {
           if (options.throw) {
             var notImplementedThrowable;
             if (typeof options.notImplemented === 'function') {
-              notImplementedThrowable = options.notImplemented(); // set whatever the user returns from their function
+              notImplementedThrowable = options.notImplemented(); // set whatever the user returns
+                                                                  // from their function
             } else {
               notImplementedThrowable = new HttpError.NotImplemented();
             }
@@ -396,7 +416,8 @@ Router.prototype.allowedMethods = function (options) {
             if (options.throw) {
               var notAllowedThrowable;
               if (typeof options.methodNotAllowed === 'function') {
-                notAllowedThrowable = options.methodNotAllowed(); // set whatever the user returns from their function
+                notAllowedThrowable = options.methodNotAllowed(); // set whatever the user returns
+                                                                  // from their function
               } else {
                 notAllowedThrowable = new HttpError.MethodNotAllowed();
               }
@@ -541,7 +562,7 @@ Router.prototype.register = function (path, methods, middleware, opts) {
 Router.prototype.route = function (name) {
   var routes = this.stack;
 
-  for (var len = routes.length, i=0; i<len; i++) {
+  for (var len = routes.length, i = 0; i < len; i++) {
     if (routes[i].name && routes[i].name === name) {
       return routes[i];
     }
@@ -674,5 +695,5 @@ Router.prototype.param = function (param, middleware) {
  * @returns {String}
  */
 Router.url = function (path, params) {
-    return Layer.prototype.url.call({path: path}, params);
+  return Layer.prototype.url.call({ path: path }, params);
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -320,7 +320,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
     ctx._matchedRoute = mostSpecificPath;
 
     layerChain = matched.pathAndMethod.reduce(function(memo, layer) {
-      memo.push(function(ctx, next) {
+      memo.push(function routerParams(ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = layer.params(path, ctx.captures, ctx.params);
         return next();

--- a/lib/router.js
+++ b/lib/router.js
@@ -603,16 +603,19 @@ Router.prototype.match = function (path, method) {
   for (var len = layers.length, i = 0; i < len; i++) {
     layer = layers[i];
 
-    debug('test %s %s', layer.path, layer.regexp);
-
+    var match = false
     if (layer.match(path)) {
       matched.path.push(layer);
 
       if (layer.methods.length === 0 || ~layer.methods.indexOf(method)) {
         matched.pathAndMethod.push(layer);
-        if (layer.methods.length) matched.route = true;
+        if (layer.methods.length) {
+          matched.route = true;
+          match = true;
+        }
       }
     }
+    debug('test %s %s %s%s', layer.methods, layer.path, layer.regexp, (match ? ' matches' : ''));
   }
 
   return matched;

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -226,6 +226,60 @@ describe('Router', function () {
       })
   });
 
+  it('executes all matching routes middleware', function (done) {
+    var app = new Koa();
+    var router = new Router();
+
+    router
+      .get('/user/count', function getCount (ctx, next) {
+        ctx.body = ctx.body || {};
+        ctx.body.count = true;
+        return next();
+      })
+      .get('/user/:id', function getUser (ctx, next) {
+        ctx.body = ctx.body || {};
+        ctx.body.getId = true;
+        return next();
+      });
+
+    request(http.createServer(app.use(router.routes()).callback()))
+      .get('/user/count')
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+        expect(res.body).to.have.property('count', true);
+        expect(res.body).to.have.property('getId', true);
+        done();
+      })
+  });
+
+  it('executes last matching route middleware', function (done) {
+    var app = new Koa();
+    var router = new Router({useFirstMatch:true});
+
+    router
+      .get('/user/count', function getCount (ctx, next) {
+        ctx.body = ctx.body || {};
+        ctx.body.count = true;
+        return next();
+      })
+      .get('/user/:id', function getUser (ctx, next) {
+        ctx.body = ctx.body || {};
+        ctx.body.getId = true;
+        return next();
+      });
+
+    request(http.createServer(app.use(router.routes()).callback()))
+      .get('/user/count')
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+        expect(res.body).to.have.property('count', true);
+        expect(res.body).to.not.have.property('getId');
+        done();
+      })
+  });
+
   it('does not run subsequent middleware without calling next', function (done) {
     var app = new Koa();
     var router = new Router();


### PR DESCRIPTION
This adds a ```Router({useFirstMatch:true})``` option when creating a router. This will cause the router to use only the first matching route in situations where ```/user/count``` and ```/user/:id``` are both routed. The previous behaviour was to chain middleware from both matching routes. I can't see the value in that behaviour, but to not break backward compatibility, I added the ```useFirstMatch``` attribute. A pair of unit tests were also added which demonstrate this behaviour. See #292.

Improved use of the ```debug``` module by:
- indicating which route (or routes) match
- listing the middleware that will be executed

The above changes were as a result of my work to [add koa2 support to express-restify-mongoose](https://github.com/jpravetz/express-restify-mongoose/tree/issue-329).