### PR TITLE
Safely convert this.path from a regular expression in setPrefix

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -204,7 +204,11 @@ Layer.prototype.setPrefix = function (prefix) {
   prefix = prefix.replace(/\/$/, '');
 
   if (this.path) {
-    this.path = prefix + this.path;
+    // safely convert this.path from a regular expression
+    this.path = (this.path instanceof RegExp)
+      ? prefix + String(this.path).substring(1, a.length -1)
+      : prefix + this.path;
+
     this.paramNames = [];
     this.regexp = pathToRegExp(this.path, this.paramNames, this.opts);
   }


### PR DESCRIPTION
Fixes an issue where paths are broken if they're defined as a regular expression and a prefix is defined.

Example:

```js
// router.prefix('/api/v1.0')

router.get(/\/foo\/bar\d+?/, function * (next) {
  this.body = 'well this works.'

  yield next
})
```

With the prefix uncommented the layer instance's `regexp` is valid, but with the prefix included, it becomes mangled to `/^\/api\/v1\.0\/foo\/bard\+(?:\/(?=$))?$/i` due to the path re being treated as a string in `setPrefix`.