### PR TITLE
Fix a bug in Router#url & append Router object to ctx.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "7"
   - "6"
-  - "5"
-  - "4"
 notifications:
   email:
     on_success: never

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -114,7 +114,7 @@ Layer.prototype.captures = function (path) {
 
 Layer.prototype.url = function (params) {
   var args = params;
-  var url = this.path;
+  var url = this.path.replace('\(\.\*\)', '');
   var toPath = pathToRegExp.compile(url);
 
   // argument is of form { key: val }

--- a/lib/router.js
+++ b/lib/router.js
@@ -314,6 +314,8 @@ Router.prototype.routes = Router.prototype.middleware = function () {
       ctx.matched = matched.path;
     }
 
+    ctx.router = router;
+
     if (!matched.route) return next();
 
     var mostSpecificPath = matched.pathAndMethod[matched.pathAndMethod.length - 1].path;

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1057,7 +1057,7 @@ describe('Router', function () {
   });
 
   describe('Router#url()', function () {
-    it('generates URL for given route', function (done) {
+    it('generates URL for given route name', function (done) {
       var app = new Koa();
       var router = new Router();
       app.use(router.routes());
@@ -1070,6 +1070,29 @@ describe('Router', function () {
       url.should.equal('/programming/how%20to%20node');
       done();
     });
+
+    it('generates URL for given route name within embedded routers', function (done) {
+        var app = new Koa();
+        var router = new Router({
+          prefix: "/books"
+        });
+
+        var embeddedRouter = new Router({
+          prefix: "/chapters"
+        });
+        embeddedRouter.get('chapters', '/:chapterName/:pageNumber', function (ctx) {
+          console.log(ctx.params);
+          ctx.status = 204;
+        });
+        router.use(embeddedRouter.routes());
+        app.use(router.routes());
+        var url = router.url('chapters', { chapterName: 'Learning ECMA6', pageNumber: 123 });
+        url.should.equal('/books/chapters/Learning%20ECMA6/123');
+        url = router.url('chapters', 'Learning ECMA6', 123);
+        url.should.equal('/books/chapters/Learning%20ECMA6/123');
+        done();
+    });
+
   });
 
   describe('Router#param()', function () {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -78,6 +78,25 @@ describe('Router', function () {
       });
   });
 
+  it('router can be accecced with ctx', function (done) {
+      var app = new Koa();
+      var router = new Router();
+      router.get('home', '/', function (ctx) {
+          ctx.body = {
+            url: ctx.router.url('home')
+          };
+      });
+      app.use(router.routes());
+      request(http.createServer(app.callback()))
+          .get('/')
+          .expect(200)
+          .end(function (err, res) {
+              if (err) return done(err);
+              expect(res.body.url).to.eql("/");
+              done();
+          });
+  });
+
   it('registers multiple middleware for one route', function(done) {
     var app = new Koa();
     var router = new Router();

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1100,7 +1100,6 @@ describe('Router', function () {
           prefix: "/chapters"
         });
         embeddedRouter.get('chapters', '/:chapterName/:pageNumber', function (ctx) {
-          console.log(ctx.params);
           ctx.status = 204;
         });
         router.use(embeddedRouter.routes());


### PR DESCRIPTION
I tried to fixed a bug found within **Router#url under the latest version**, where I get errors when trying to get a url with a name provided in an embedded router middleware, the change doesn't affect other parts(at least all test is passed :b ).
Also I find that in Koa2 you cannot access router object as previous version, where you can use:
```javascript
router.get('book-detail', '/books/:book_id', function *() {
     // some code...
});
router.post('create-book', '/books', function *() {
    // some code...
    this.redirect(this.app.url('book-detail', {book_id: book.id}));
});
```

So I append the router object to ctx. This leads to the following usage:
```javascript
router.get('book-detail', '/books/:book_id', function (ctx) {
    // some code...
});
router.post('create-book', '/books', function (ctx) {
    // some code...
    ctx.redirect(ctx.router.url('book-detail', {book_id: book.id}));
});
```
All test are passed under development environment.