### PR TITLE
Comma-separate list of Allow header methods (#273)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -426,13 +426,13 @@ Router.prototype.allowedMethods = function (options) {
             throw notImplementedThrowable;
           } else {
             ctx.status = 501;
-            ctx.set('Allow', allowedArr);
+            ctx.set('Allow', allowedArr.join(', '));
           }
         } else if (allowedArr.length) {
           if (ctx.method === 'OPTIONS') {
             ctx.status = 200;
             ctx.body = '';
-            ctx.set('Allow', allowedArr);
+            ctx.set('Allow', allowedArr.join(', '));
           } else if (!allowed[ctx.method]) {
             if (options.throw) {
               var notAllowedThrowable;
@@ -444,7 +444,7 @@ Router.prototype.allowedMethods = function (options) {
               throw notAllowedThrowable;
             } else {
               ctx.status = 405;
-              ctx.set('Allow', allowedArr);
+              ctx.set('Allow', allowedArr.join(', '));
             }
           }
         }

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -754,6 +754,28 @@ describe('Router', function () {
         done();
       });
     });
+
+    it('sets the allowed methods to a single Allow header #273', function (done) {
+      // https://tools.ietf.org/html/rfc7231#section-7.4.1
+      var app = new Koa();
+      var router = new Router();
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      router.get('/', function (ctx, next) {});
+
+      request(http.createServer(app.callback()))
+        .options('/')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.header.should.have.property('allow', 'HEAD, GET');
+          let allowHeaders = res.res.rawHeaders.filter((item) => item == 'Allow');
+          expect(allowHeaders.length).to.eql(1);
+          done();
+        });
+    });
+
   });
 
   it('supports custom routing detect path: ctx.routerPath', function (done) {


### PR DESCRIPTION
> When an options request is made to an app using koa-router, multiple "Allow" headers are set instead of one header with a comma separated value.

> For example, I've got a route that currently only supports GET requests. When I ping it with an OPTIONS request, it should attach a header like:

```
Allow: HEAD, GET
```

> but instead if I inspect the response headers with chrome dev tools, I get

```
Allow: HEAD
Allow: GET
```

RFC isn't super clear about having several of these headers. Node
happens to parse them as a single comma-separated list, but this
behavior isn't the same in all programs. This should be non-breaking for
almost all applications and fixes an issue in #273

https://tools.ietf.org/html/rfc7231#section-7.4.1

fixes #273