### PR TITLE
try to resolve #244

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -262,9 +262,10 @@ Router.prototype.use = function () {
   middleware.forEach(function (m) {
     if (m.router) {
       m.router.stack.forEach(function (nestedLayer) {
-        if (path) nestedLayer.setPrefix(path);
-        if (router.opts.prefix) nestedLayer.setPrefix(router.opts.prefix);
-        router.stack.push(nestedLayer);
+        let temp = new Layer(nestedLayer.path, nestedLayer.methods, nestedLayer.stack, nestedLayer.opts);
+        if (path) temp.setPrefix(path);
+        if (router.opts.prefix) temp.setPrefix(router.opts.prefix);
+        router.stack.push(temp);
       });
 
       if (router.params) {


### PR DESCRIPTION
The problem was in impossibility to reuse router instance with multiple prefixes properly, because layer instance inside router was overwritten with new routes.

And it is real situation when previous routes won't be accessible anymore. That's why we need to create layer instance in every iteration.

At least, this fix resolves issue in #244 but I would to discover bad cases for this fix if they exist.