### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "route"
   ],
   "dependencies": {
-    "debug": "^2.2.0",
+    "debug": "^3.1.0",
     "http-errors": "^1.3.1",
     "koa-compose": "^3.0.0",
     "methods": "^1.0.1",


### PR DESCRIPTION
✗ Low severity vulnerability found on debug@2.6.8
- desc: Regular Expression Denial of Service (ReDoS)
- info: https://snyk.io/vuln/npm:debug:20170905
- from: koa-router@7.2.1 > debug@2.6.8
Your dependencies are out of date, otherwise you would be using a newer debug than debug@2.6.8.