### PR TITLE
Support named routes with RegExp when using .all() method

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -467,7 +467,7 @@ Router.prototype.allowedMethods = function (options) {
 Router.prototype.all = function (name, path, middleware) {
   var middleware;
 
-  if (typeof path === 'string') {
+  if (typeof path === 'string' || path instanceof RegExp) {
     middleware = Array.prototype.slice.call(arguments, 2);
   } else {
     middleware = Array.prototype.slice.call(arguments, 1);

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -796,6 +796,11 @@ describe('Router', function () {
         router[method](/^\/\w$/i, function () {}).should.equal(router);
       });
     });
+	
+    it('registers route with with a given name when using .all()', function() {
+      var router = new Router();
+      router.all('name', /^\/$/i, function () {}).should.equal(router);
+    });
 
     it('registers route with a given name', function () {
       var router = new Router();


### PR DESCRIPTION
Adds the same check that is used [here](https://github.com/MartinKolarik/koa-router/blob/7b77a3e0d5a2b99817330ed5adf852705e3d5959/lib/router.js#L194).