### PR TITLE
fix(readme): return next()

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ router.get(
   function (ctx, next) {
     return User.findOne(ctx.params.id).then(function(user) {
       ctx.user = user;
-      next();
+      return next();
     });
   },
   function (ctx) {


### PR DESCRIPTION
The current example would end the request prematurely.