### PR TITLE
Log a warning if a configured path is unreachable

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -9,6 +9,7 @@ var debug = require('debug')('koa-router');
 var compose = require('koa-compose');
 var HttpError = require('http-errors');
 var methods = require('methods');
+var parsePath = require('path-to-regexp').parse;
 var Layer = require('./layer');
 
 /**
@@ -567,9 +568,50 @@ Router.prototype.register = function (path, methods, middleware, opts) {
     route.param(param, this.params[param]);
   }, this);
 
+  router.verifyPathReachable(path);
+
   stack.push(route);
 
   return route;
+};
+
+/**
+ * Verify that the given path is reachable, based on the already registered
+ * routes. If it is not, log a warning to the console.
+ *
+ * @param {string} path
+ * @returns {boolean} Whether the path is reachable.
+ * @private
+ */
+
+Router.prototype.verifyPathReachable = function (path) {
+  if (!(path instanceof String)) {
+    // bail if the path is not a simple string
+    return true;
+  }
+
+  var parts = parsePath(path);
+  var testPath = '';
+  parts.forEach(function (part) {
+    if (part instanceof String) {
+      testPath += part;
+    } else {
+      testPath += part.prefix + 'test';
+    }
+  });
+
+  var blockingRoute = this.stack.find(function (route) {
+    return route.test(testPath);
+  });
+
+  if (blockingRoute) {
+    console.warn('[koa-router] path %s is unreachable, matched first by %s',
+      path,
+      blockingRoute.path);
+    return false;
+  }
+
+  return true;
 };
 
 /**

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1661,4 +1661,18 @@ describe('Router', function () {
       url.should.equal('/programming/how%20to%20node');
     });
   });
+
+  describe('Router#verifyPathReachable()', function () {
+    it('should return true for a reachable path', function () {
+      var router = new Router();
+      router.get('/objects', function (ctx, next) {});
+      expect(router.verifyPathReachable('/objects/list')).to.be.true;
+    });
+
+    it('should return false for an unreachable path', function () {
+      var router = new Router();
+      router.get('/objects/:id', function (ctx, next) {});
+      expect(router.verifyPathReachable('/objects/list')).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
Partial solution for https://github.com/alexmingoia/koa-router/issues/394. If a route is configured with a string, and a previous route would be matched first, log a warning. Doesn't handle cases where path is passed as a regex (infinite possibilities?) or as an array.