### PR TITLE
Feature: Router#url() accepts extra query parameters as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install koa-router
 ```
 
 ## API Reference
-  
+
 * [koa-router](#module_koa-router)
     * [Router](#exp_module_koa-router--Router) ⏏
         * [new Router([opts])](#new_module_koa-router--Router_new)
@@ -44,7 +44,7 @@ npm install koa-router
             * [.allowedMethods([options])](#module_koa-router--Router+allowedMethods) ⇒ <code>function</code>
             * [.redirect(source, destination, code)](#module_koa-router--Router+redirect) ⇒ <code>Router</code>
             * [.route(name)](#module_koa-router--Router+route) ⇒ <code>Layer</code> &#124; <code>false</code>
-            * [.url(name, params)](#module_koa-router--Router+url) ⇒ <code>String</code> &#124; <code>Error</code>
+            * [.url(name, params [, options])](#module_koa-router--Router+url) ⇒ <code>String</code> &#124; <code>Error</code>
             * [.param(param, middleware)](#module_koa-router--Router+param) ⇒ <code>Router</code>
         * _static_
             * [.url(path, params)](#module_koa-router--Router.url) ⇒ <code>String</code>
@@ -224,9 +224,9 @@ sequentially, requests start at the first middleware and work their way
 
 | Param | Type |
 | --- | --- |
-| [path] | <code>String</code> | 
-| middleware | <code>function</code> | 
-| [...] | <code>function</code> | 
+| [path] | <code>String</code> |
+| middleware | <code>function</code> |
+| [...] | <code>function</code> |
 
 **Example**  
 ```javascript
@@ -252,7 +252,7 @@ Set the path prefix for a Router instance that was already initialized.
 
 | Param | Type |
 | --- | --- |
-| prefix | <code>String</code> | 
+| prefix | <code>String</code> |
 
 **Example**  
 ```javascript
@@ -340,11 +340,11 @@ Lookup route with given `name`.
 
 | Param | Type |
 | --- | --- |
-| name | <code>String</code> | 
+| name | <code>String</code> |
 
 <a name="module_koa-router--Router+url"></a>
 
-#### router.url(name, params) ⇒ <code>String</code> &#124; <code>Error</code>
+#### router.url(name, params [, options]) ⇒ <code>String</code> &#124; <code>Error</code>
 Generate URL for route. Takes a route name and map of named `params`.
 
 **Kind**: instance method of <code>[Router](#exp_module_koa-router--Router)</code>  
@@ -353,7 +353,8 @@ Generate URL for route. Takes a route name and map of named `params`.
 | --- | --- | --- |
 | name | <code>String</code> | route name |
 | params | <code>Object</code> | url parameters |
-
+| [options] | <code>Object</code> | options parameter |
+| [options.query] | <code>Object</code> &#124; <code>String</code> | query options |
 **Example**  
 ```javascript
 router.get('user', '/users/:id', function (ctx, next) {
@@ -365,6 +366,12 @@ router.url('user', 3);
 
 router.url('user', { id: 3 });
 // => "/users/3"
+
+router.url('user', { id: 3 }, { query: { limit: 1 } });
+// => "/users/3?limit=1"
+
+router.url('user', { id: 3 }, { query: "limit=1" });
+// => "/users/3?limit=1"
 
 router.use(function (ctx, next) {
   // redirect to named route
@@ -381,8 +388,8 @@ validation.
 
 | Param | Type |
 | --- | --- |
-| param | <code>String</code> | 
-| middleware | <code>function</code> | 
+| param | <code>String</code> |
+| middleware | <code>function</code> |
 
 **Example**  
 ```javascript

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Generate URL for route. Takes a route name and map of named `params`.
 | params | <code>Object</code> | url parameters |
 | [options] | <code>Object</code> | options parameter |
 | [options.query] | <code>Object</code> &#124; <code>String</code> | query options |
+
 **Example**  
 ```javascript
 router.get('user', '/users/:id', function (ctx, next) {

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,5 +1,6 @@
 var debug = require('debug')('koa-router');
 var pathToRegExp = require('path-to-regexp');
+var uri = require('urijs');
 
 module.exports = Layer;
 
@@ -112,27 +113,42 @@ Layer.prototype.captures = function (path) {
  * @private
  */
 
-Layer.prototype.url = function (params) {
+Layer.prototype.url = function (params, options) {
   var args = params;
   var url = this.path.replace('\(\.\*\)', '');
   var toPath = pathToRegExp.compile(url);
+  var replaced;
 
-  // argument is of form { key: val }
   if (typeof params != 'object') {
     args = Array.prototype.slice.call(arguments);
+    if (typeof args[args.length - 1] == 'object') {
+      options = args[args.length - 1];
+      args = args.slice(0, args.length - 1);
+    }
   }
 
+  var tokens = pathToRegExp.parse(url);
+  var replace = {};
+
   if (args instanceof Array) {
-    var tokens = pathToRegExp.parse(url);
-    var replace = {};
     for (var len = tokens.length, i=0, j=0; i<len; i++) {
       if (tokens[i].name) replace[tokens[i].name] = args[j++];
     }
-    return toPath(replace);
+  } else if (tokens.some(token => token.name)) {
+    replace = params;
+  } else {
+    options = params;
   }
-  else {
-    return toPath(params);
+
+  replaced = toPath(replace);
+
+  if (options && options.query) {
+    var replaced = new uri(replaced)
+    replaced.search(options.query);
+    return replaced.toString();
   }
+
+  return replaced;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "http-errors": "^1.3.1",
     "koa-compose": "^3.0.0",
     "methods": "^1.0.1",
-    "path-to-regexp": "^1.1.1"
+    "path-to-regexp": "^1.1.1",
+    "urijs": "^1.19.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1134,6 +1134,31 @@ describe('Router', function () {
         done();
     });
 
+    it('generates URL for given route name with params and query params', function(done) {
+        var app = new Koa();
+        var router = new Router();
+        router.get('categories', '/categories/:name', function (ctx) {
+          ctx.status = 204;
+        });
+        var url = router.url('categories', { name: 'programming' }, {
+          query: { page: 3, limit: 10 }
+        });
+        url.should.equal('/categories/programming?page=3&limit=10');
+        done();
+    })
+
+    it('generates URL for given route name without params and query params', function(done) {
+        var app = new Koa();
+        var router = new Router();
+        router.get('category', '/category', function (ctx) {
+          ctx.status = 204;
+        });
+        var url = router.url('category', {
+          query: { page: 3, limit: 10 }
+        });
+        url.should.equal('/category?page=3&limit=10');
+        done();
+    })
   });
 
   describe('Router#param()', function () {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1134,7 +1134,7 @@ describe('Router', function () {
         done();
     });
 
-    it('generates URL for given route name with params and query params', function(done) {
+    it('generates URL for given route name with params object and query params', function(done) {
         var app = new Koa();
         var router = new Router();
         router.get('categories', '/categories/:name', function (ctx) {
@@ -1146,6 +1146,20 @@ describe('Router', function () {
         url.should.equal('/categories/programming?page=3&limit=10');
         done();
     })
+
+    it('generates URL for given route name with params and query params', function(done) {
+        var app = new Koa();
+        var router = new Router();
+        router.get('books', '/books/:category/:id', function (ctx) {
+          ctx.status = 204;
+        });
+        var url = router.url('books', 'programming', 4, {
+          query: { page: 3, limit: 10 }
+        });
+        url.should.equal('/books/programming/4?page=3&limit=10');
+        done();
+    })
+
 
     it('generates URL for given route name without params and query params', function(done) {
         var app = new Koa();

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1134,19 +1134,6 @@ describe('Router', function () {
         done();
     });
 
-    it('generates URL for given route name with params object and query params', function(done) {
-        var app = new Koa();
-        var router = new Router();
-        router.get('categories', '/categories/:name', function (ctx) {
-          ctx.status = 204;
-        });
-        var url = router.url('categories', { name: 'programming' }, {
-          query: { page: 3, limit: 10 }
-        });
-        url.should.equal('/categories/programming?page=3&limit=10');
-        done();
-    })
-
     it('generates URL for given route name with params and query params', function(done) {
         var app = new Koa();
         var router = new Router();
@@ -1156,6 +1143,16 @@ describe('Router', function () {
         var url = router.url('books', 'programming', 4, {
           query: { page: 3, limit: 10 }
         });
+        url.should.equal('/books/programming/4?page=3&limit=10');
+        var url = router.url('books',
+          { category: 'programming', id: 4 },
+          { query: { page: 3, limit: 10 }}
+        );
+        url.should.equal('/books/programming/4?page=3&limit=10');
+        var url = router.url('books',
+          { category: 'programming', id: 4 },
+          { query: 'page=3&limit=10' }
+        );
         url.should.equal('/books/programming/4?page=3&limit=10');
         done();
     })


### PR DESCRIPTION
From "Add query parameters argument to Router.prototype.url method" #227 discussion



#### router.url(name, params [, options]) ⇒ <code>String</code> &#124; <code>Error</code>
| Param | Type | Description |
| --- | --- | --- |
| name | <code>String</code> | route name |
| params | <code>Object</code> | url parameters |
| [options] | <code>Object</code> | options parameter |
| [options.query] | <code>Object</code> &#124; <code>String</code> | query options |

**Example**  
```javascript
router.url('user', { id: 3 }, { query: { limit: 1 } });
// => "/users/3?limit=1"

router.url('user', { id: 3 }, { query: "limit=1" });
// => "/users/3?limit=1"
```