### PR TITLE
Updated readme with correct Boom usage for allowedMethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ var router = new Router();
 app.use(router.routes());
 app.use(router.allowedMethods({
   throw: true,
-  notImplemented: () => new Boom.notImplemented(),
-  methodNotAllowed: () => new Boom.methodNotAllowed()
+  notImplemented: Boom.notImplemented(),
+  methodNotAllowed: Boom.methodNotAllowed()
 }));
 ```
 <a name="module_koa-router--Router+redirect"></a>


### PR DESCRIPTION
Both the Boom.notImplemented and Boom.methodNotAllowed are not constructors.  