### PR TITLE
remove default wildcard prefix for nested routers

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -243,7 +243,7 @@ Router.prototype.del = Router.prototype['delete'];
 Router.prototype.use = function () {
   var router = this;
   var middleware = Array.prototype.slice.call(arguments);
-  var path = '(.*)';
+  var path;
 
   // support array of paths
   if (Array.isArray(middleware[0]) && typeof middleware[0][0] === 'string') {
@@ -273,7 +273,7 @@ Router.prototype.use = function () {
         });
       }
     } else {
-      router.register(path, [], m, { end: false, ignoreCaptures: !hasPath });
+      router.register(path || '(.*)', [], m, { end: false, ignoreCaptures: !hasPath });
     }
   });
 

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1038,6 +1038,38 @@ describe('Router', function () {
           done();
         });
     });
+
+    it('does not add an erroneous (.*) to unprefiexed nested routers - gh-369 gh-410', function (done) {
+      var app = new Koa();
+      var router = new Router();
+      var nested = new Router();
+      var called = 0;
+
+      nested
+        .get('/', (ctx, next) => {
+          ctx.body = 'root';
+          called += 1;
+          return next();
+        })
+        .get('/test', (ctx, next) => {
+          ctx.body = 'test';
+          called += 1;
+          return next();
+        });
+
+      router.use(nested.routes());
+      app.use(router.routes());
+
+      request(app.callback())
+        .get('/test')
+        .expect(200)
+        .expect('test')
+        .end(function (err, res) {
+          if (err) return done(err);
+          expect(called).to.eql(1, 'too many routes matched');
+          done();
+        });
+    });
   });
 
   describe('Router#register()', function () {


### PR DESCRIPTION
Fixes what looks like a regression in 8665620 in which `path` inside of
`.use()` is defaulted to a wildcard `(.*)` instead of remaining
undefined while the line:

```js
if (path) nestedLayer.setPrefix(path)
```

runs. Where previously the line:

```js
var path;
```

resulted in no `setPrefix` call the current code (`var path = '(.*)';`) _does_ allow `setPrefix` to be called on the nested layer and creates erroneous wildcard suffixes to route segments.

https://github.com/alexmingoia/koa-router/blob/840591d4f660ddde98aedc689dea862a7e63f55b/lib/router.js#L265

This fixes #369 and #410
A test case has been added.