### PR TITLE
Add routerPath to context

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -343,6 +343,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = layer.params(path, ctx.captures, ctx.params);
         ctx.routerName = layer.name;
+        ctx.routerPath = layer.path;
         return next();
       });
       return memo.concat(layer.stack);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,622 +4,332 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "accepts": {
-      "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+    "acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+        "acorn": "3.3.0"
       }
     },
-    "amdefine": {
-      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
-      "dev": true
-    },
-    "ansi-escape-sequences": {
-      "version": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-1.0.2.tgz",
-      "integrity": "sha1-q7G+lnXM8Ezgb8U5v2wF49Q3ZCI=",
+    "app-usage-stats": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/app-usage-stats/-/app-usage-stats-0.4.1.tgz",
+      "integrity": "sha1-l+ubibVnj6LdyXk7EphijMIYQp8=",
       "dev": true,
       "requires": {
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz"
-      }
-    },
-    "ansi-regex": {
-      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "any-promise": {
-      "version": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
-    "archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
-    },
-    "array-back": {
-      "version": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-      "integrity": "sha1-8RKKXPG5HIC+1KIY+MW2NcixBmM=",
-      "dev": true,
-      "requires": {
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+        "array-back": "1.0.4",
+        "core-js": "2.5.4",
+        "feature-detect-es6": "1.4.0",
+        "home-path": "1.0.5",
+        "test-value": "2.1.0",
+        "usage-stats": "0.8.6"
       },
       "dependencies": {
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
-    },
-    "array-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
-      "dev": true
-    },
-    "array-slice": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
-      "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
-      "dev": true
-    },
-    "array-tools": {
-      "version": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-      "integrity": "sha1-FFdx9/nJTpjMXqQZapm4MjruGK4=",
-      "dev": true,
-      "requires": {
-        "object-tools": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "array-uniq": {
-      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
-    },
-    "asap": {
-      "version": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
-      "dev": true
-    },
-    "async": {
-      "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-      "dev": true
-    },
-    "beeper": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz",
-      "integrity": "sha1-XudH8ce9lnZYtoOTZDCu51OVWjQ=",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-      }
-    },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
-    },
-    "cache-point": {
-      "version": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.3.tgz",
-      "integrity": "sha1-37le3f1DHAv1VDB4eapcKIkRAeA=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-      }
-    },
-    "catharsis": {
-      "version": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.8.tgz",
-      "integrity": "sha1-aTR59DqsVJ2Aa9c+kkzQ2USVGgY=",
-      "dev": true,
-      "requires": {
-        "underscore-contrib": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz"
-      }
-    },
-    "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-      }
-    },
-    "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-      "dev": true
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-      "dev": true
-    },
-    "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "collect-all": {
-      "version": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
-      "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
-      "dev": true,
-      "requires": {
-        "stream-connect": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-        "stream-via": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "collect-json": {
-      "version": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-      "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
-      "dev": true,
-      "requires": {
-        "collect-all": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.2.tgz",
-        "stream-connect": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-        "stream-via": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.3.tgz"
-      },
-      "dependencies": {
-        "collect-all": {
-          "version": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.2.tgz",
-          "integrity": "sha1-OUUPHnqmCGVwoAa86TzPEhinfqE=",
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "stream-connect": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-            "stream-via": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.3.tgz"
+            "typical": "2.6.1"
           }
         },
-        "stream-via": {
-          "version": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.3.tgz",
-          "integrity": "sha1-zr0ypaWddLO2jjQElC6GcYStSsk=",
+        "core-js": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
           "dev": true
-        }
-      }
-    },
-    "column-layout": {
-      "version": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
-      "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "collect-json": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-        "command-line-args": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-        "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-        "object-tools": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-        "wordwrapjs": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-all": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz"
-          }
         },
-        "command-line-args": {
-          "version": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "command-line-usage": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-            "find-replace": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.2.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-          }
-        },
-        "command-line-usage": {
-          "version": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "column-layout": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
-            "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-            "wordwrapjs": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz"
-          }
-        },
-        "object-tools": {
-          "version": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-          "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-json": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-            "object-get": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-            "test-value": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+            "array-back": "1.0.4"
           }
         },
         "test-value": {
-          "version": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
           }
         },
         "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
       }
     },
-    "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-      }
-    },
-    "command-line-args": {
-      "version": "https://registry.npmjs.org/command-line-args/-/command-line-args-0.5.9.tgz",
-      "integrity": "sha1-1EFzO6mxF4ZDPlPc8b3kcr/mm2w=",
-      "dev": true,
-      "requires": {
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-        "handlebars-ansi": "https://registry.npmjs.org/handlebars-ansi/-/handlebars-ansi-0.2.0.tgz",
-        "nature": "https://registry.npmjs.org/nature/-/nature-0.5.7.tgz",
-        "object-tools": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-        "string-tools": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-1.0.0.tgz",
-        "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.4",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
-        "async": {
-          "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "handlebars": {
-          "version": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-          "dev": true,
-          "requires": {
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz"
-          }
-        },
-        "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-          }
-        },
-        "uglify-js": {
-          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-              }
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true,
-          "optional": true
+        "core-js": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
+          "dev": true
         }
       }
     },
-    "command-line-tool": {
-      "version": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
-      "integrity": "sha1-+H1pd/VrvdLV38+UY0XdLNnGpTo=",
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "command-line-args": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.1.tgz",
-        "command-line-usage": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.3.tgz",
-        "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+        "core-js": "2.5.4",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
+    "cli-commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cli-commands/-/cli-commands-0.1.0.tgz",
+      "integrity": "sha1-xXysxAa7z57iFkZgcWHtQy71oFo=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "3.0.0",
+        "command-line-args": "3.0.5",
+        "command-line-commands": "1.0.4",
+        "command-line-usage": "3.0.8"
       },
       "dependencies": {
         "ansi-escape-sequences": {
-          "version": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
+          "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-all": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz"
+            "array-back": "1.0.4"
+          }
+        },
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "2.6.1"
           }
         },
         "command-line-args": {
-          "version": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.1.tgz",
-          "integrity": "sha1-YXusChXTSuhI7aKqUT7Xbv3EivU=",
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
+          "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-            "find-replace": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.2.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.4.0",
+            "find-replace": "1.0.3",
+            "typical": "2.6.1"
+          }
+        },
+        "command-line-usage": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
+          "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "3.0.0",
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.4.0",
+            "table-layout": "0.3.0",
+            "typical": "2.6.1"
+          }
+        },
+        "core-js": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
+          "dev": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true
+        },
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "find-replace": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+          "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "test-value": "2.1.0"
+          }
+        },
+        "reduce-flatten": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+          "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+          "dev": true
+        },
+        "table-layout": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
+          "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "core-js": "2.5.4",
+            "deep-extend": "0.4.2",
+            "feature-detect-es6": "1.4.0",
+            "typical": "2.6.1",
+            "wordwrapjs": "2.0.0"
+          }
+        },
+        "test-value": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
           }
         },
         "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "dev": true
+        },
+        "wordwrapjs": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
+          "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.4.0",
+            "reduce-flatten": "1.0.1",
+            "typical": "2.6.1"
+          }
+        }
+      }
+    },
+    "command-line-commands": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-1.0.4.tgz",
+      "integrity": "sha1-A0+bFntRiK+9z2su+7FQ/IRCwys=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "feature-detect-es6": "1.4.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "2.6.1"
+          }
+        },
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "typical": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
       }
     },
-    "command-line-usage": {
-      "version": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.3.tgz",
-      "integrity": "sha1-zF9zSs+66OGANSxf9Lu0gx5+XpQ=",
+    "config-master": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/config-master/-/config-master-2.0.4.tgz",
+      "integrity": "sha1-50lQXF0/lG8vrTx23+cfymiXUdw=",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-        "table-layout": "https://registry.npmjs.org/table-layout/-/table-layout-0.2.2.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+        "babel-polyfill": "6.26.0",
+        "feature-detect-es6": "1.4.0",
+        "walk-back": "2.0.1"
       },
       "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-all": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz"
+            "typical": "2.6.1"
+          }
+        },
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
           }
         },
         "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-      "dev": true
-    },
-    "common-sequence": {
-      "version": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
-      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
-      "dev": true
-    },
-    "component-emitter": {
-      "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "console-dope": {
-      "version": "https://registry.npmjs.org/console-dope/-/console-dope-0.3.6.tgz",
-      "integrity": "sha1-2G8Ku2okd55VtiiqXRcmT4Esxgw=",
-      "dev": true
-    },
-    "content-disposition": {
-      "version": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
-    },
-    "content-type": {
-      "version": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
-      "dev": true
-    },
-    "cookiejar": {
-      "version": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-      "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
-      "dev": true
-    },
-    "cookies": {
-      "version": "https://registry.npmjs.org/cookies/-/cookies-0.7.0.tgz",
-      "integrity": "sha1-C8lh2RDDUlSYD8fJ7/XaEgEbvwA=",
-      "dev": true,
-      "requires": {
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-        "keygrip": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz"
-      }
-    },
-    "core-js": {
-      "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
-    "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
-      "dev": true
-    },
-    "ddata": {
-      "version": "https://registry.npmjs.org/ddata/-/ddata-0.1.27.tgz",
-      "integrity": "sha1-vAkH8pGpfYEDpX0Jjgp4yNrP0FE=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-        "object-get": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-        "reduce-flatten": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-        "string-tools": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
-        "test-value": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz"
-      },
-      "dependencies": {
-        "async": {
-          "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "handlebars": {
-          "version": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-          "dev": true,
-          "requires": {
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz"
-          }
-        },
-        "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-          }
-        },
-        "string-tools": {
-          "version": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
-          "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         },
-        "uglify-js": {
-          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-              }
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true,
-          "optional": true
+        "walk-back": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+          "dev": true
         }
       }
     },
@@ -631,209 +341,20 @@
         "ms": "2.0.0"
       }
     },
-    "deep-equal": {
-      "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+    "defer-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defer-promise/-/defer-promise-1.0.1.tgz",
+      "integrity": "sha1-HKb/7dvO8XFd16riXHYW+a4iky8=",
       "dev": true
     },
-    "deep-extend": {
-      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-      "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-      "dev": true
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+    "espree": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
+      "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2"
-      }
-    },
-    "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "delegates": {
-      "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
-    },
-    "depd": {
-      "version": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
-      "dev": true
-    },
-    "deprecated": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-      "dev": true
-    },
-    "destroy": {
-      "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
-    },
-    "detect-file": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true,
-      "requires": {
-        "fs-exists-sync": "0.1.0"
-      }
-    },
-    "diff": {
-      "version": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
-      "dev": true
-    },
-    "dmd": {
-      "version": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
-      "integrity": "sha1-sTBLmKVwCmv+Xc+RvmV8mBcApLw=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "command-line-tool": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
-        "common-sequence": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
-        "ddata": "https://registry.npmjs.org/ddata/-/ddata-0.1.27.tgz",
-        "file-set": "https://registry.npmjs.org/file-set/-/file-set-1.0.2.tgz",
-        "handlebars-array": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
-        "handlebars-comparison": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
-        "handlebars-json": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
-        "handlebars-regexp": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
-        "handlebars-string": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
-        "object-tools": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-        "reduce-unique": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-        "reduce-without": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-        "stream-handlebars": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
-        "string-tools": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
-        "walk-back": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz"
-      },
-      "dependencies": {
-        "object-tools": {
-          "version": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-          "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-json": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-            "object-get": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-            "test-value": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-          }
-        },
-        "string-tools": {
-          "version": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
-          "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
-          "dev": true
-        },
-        "test-value": {
-          "version": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-          }
-        },
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
-        }
-      }
-    },
-    "ee-first": {
-      "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
-    },
-    "end-of-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-      "dev": true,
-      "requires": {
-        "once": "1.3.3"
-      },
-      "dependencies": {
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
-        }
-      }
-    },
-    "error-inject": {
-      "version": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
-      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=",
-      "dev": true
-    },
-    "escape-html": {
-      "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
-    },
-    "expand-tilde": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+        "acorn": "3.3.0",
+        "acorn-jsx": "3.0.1"
       }
     },
     "expect.js": {
@@ -842,1386 +363,1437 @@
       "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
       "dev": true
     },
-    "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-      "dev": true
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+    "fs-then-native": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-1.0.2.tgz",
+      "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "time-stamp": "1.1.0"
-      }
-    },
-    "feature-detect-es6": {
-      "version": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-      "integrity": "sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz"
-      }
-    },
-    "file-set": {
-      "version": "https://registry.npmjs.org/file-set/-/file-set-1.0.2.tgz",
-      "integrity": "sha1-rk6bhl9O3yyI+IBNAtcEIB0olEY=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-      }
-    },
-    "filter-where": {
-      "version": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
-      "integrity": "sha1-GwQlae3ONrwcTp9zdA0sTi/u930=",
-      "dev": true,
-      "requires": {
-        "test-value": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz"
+        "feature-detect-es6": "1.4.0"
       },
       "dependencies": {
-        "test-value": {
-          "version": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+            "typical": "2.6.1"
+          }
+        },
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
           }
         },
         "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
       }
     },
-    "find-index": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-      "dev": true
-    },
-    "find-replace": {
-      "version": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.2.tgz",
-      "integrity": "sha1-otbOdA0V8NkrGyZ2PizpwONh/Zg=",
+    "handlebars": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+      "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
       "dev": true,
       "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "test-value": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz"
-      }
-    },
-    "findup-sync": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true,
-      "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
-      }
-    },
-    "fined": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "2.0.2",
-        "is-plain-object": "2.0.4",
-        "object.defaults": "1.1.0",
-        "object.pick": "1.3.0",
-        "parse-filepath": "1.0.1"
-      },
-      "dependencies": {
-        "expand-tilde": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true,
-          "requires": {
-            "homedir-polyfill": "1.0.1"
-          }
-        }
-      }
-    },
-    "first-chunk-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-      "dev": true
-    },
-    "flagged-respawn": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
-      "dev": true
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
-    },
-    "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-      "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
-      "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
-      }
-    },
-    "formidable": {
-      "version": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-      "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
-      "dev": true
-    },
-    "fresh": {
-      "version": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
-      "dev": true
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-      "dev": true
-    },
-    "fs-extra": {
-      "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-        "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-      }
-    },
-    "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "gaze": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true,
-      "requires": {
-        "globule": "0.1.0"
-      }
-    },
-    "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-      "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-stream": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-      "dev": true,
-      "requires": {
-        "glob": "4.5.3",
-        "glob2base": "0.0.12",
-        "minimatch": "2.0.10",
-        "ordered-read-streams": "0.1.0",
-        "through2": "0.6.5",
-        "unique-stream": "1.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "2.0.10",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-          }
-        }
-      }
-    },
-    "glob-watcher": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "dev": true,
-      "requires": {
-        "gaze": "0.5.2"
-      }
-    },
-    "glob2base": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true,
-      "requires": {
-        "find-index": "0.1.1"
-      }
-    },
-    "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true,
-      "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
-      }
-    },
-    "global-prefix": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "0.2.0",
-        "which": "1.3.0"
-      },
-      "dependencies": {
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        }
-      }
-    },
-    "globule": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-      "dev": true,
-      "requires": {
-        "glob": "3.1.21",
-        "lodash": "1.0.2",
-        "minimatch": "0.2.14"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
-          }
-        },
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-          }
-        }
-      }
-    },
-    "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
-      "dev": true
-    },
-    "growl": {
-      "version": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
-      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
-      "dev": true
-    },
-    "gulp": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-      "dev": true,
-      "requires": {
-        "archy": "1.0.0",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "deprecated": "0.0.1",
-        "gulp-util": "3.0.8",
-        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-        "liftoff": "2.3.0",
-        "minimist": "1.2.0",
-        "orchestrator": "0.3.8",
-        "pretty-hrtime": "1.0.3",
-        "semver": "4.3.6",
-        "tildify": "1.2.0",
-        "v8flags": "2.1.1",
-        "vinyl-fs": "0.3.14"
+        "optimist": "0.6.1",
+        "source-map": "0.1.43",
+        "uglify-js": "2.3.6"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        }
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-        "beeper": "1.1.1",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "dateformat": "2.0.0",
-        "fancy-log": "1.3.0",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
-        }
-      }
-    },
-    "gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true,
-      "requires": {
-        "glogg": "1.0.0"
-      }
-    },
-    "handlebars-ansi": {
-      "version": "https://registry.npmjs.org/handlebars-ansi/-/handlebars-ansi-0.2.0.tgz",
-      "integrity": "sha1-41EXza5UnJYapbitXADnTAGRBeU=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-1.0.2.tgz"
-      }
-    },
-    "handlebars-array": {
-      "version": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
-      "integrity": "sha1-3Vg5WlJh1mGYjo13Ug67+q3GvSQ=",
-      "dev": true,
-      "requires": {
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz"
-      }
-    },
-    "handlebars-comparison": {
-      "version": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
-      "integrity": "sha1-sXuV0sKYV45K6tOPX6xG6PYAWFU=",
-      "dev": true,
-      "requires": {
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz"
-      }
-    },
-    "handlebars-json": {
-      "version": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
-      "integrity": "sha1-Lvh7t4JVHNZFu0aRuCTpZT7AJQQ=",
-      "dev": true
-    },
-    "handlebars-regexp": {
-      "version": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
-      "integrity": "sha1-X0fwZyYOm6jlLxooCRf3DeOfEeQ=",
-      "dev": true
-    },
-    "handlebars-string": {
-      "version": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
-      "integrity": "sha1-ufkiCKl5z89R/0qQ3voYPcYpQso=",
-      "dev": true,
-      "requires": {
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-        "string-tools": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz"
-      }
-    },
-    "has-ansi": {
-      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-      }
-    },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
-    },
-    "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "1.0.0"
-      }
-    },
-    "http-assert": {
-      "version": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
-      "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
-      "dev": true,
-      "requires": {
-        "deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz"
-      },
-      "dependencies": {
-        "http-errors": {
-          "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-          "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-            "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
           }
-        },
-        "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
-        },
-        "statuses": {
-          "version": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
         }
       }
+    },
+    "home-path": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
+      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
+      "dev": true
     },
     "http-errors": {
-      "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-      "integrity": "sha1-scs9gmD9jiOGytMYkEWUM3LUghE=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
-      }
-    },
-    "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
-      "dev": true,
-      "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      }
-    },
-    "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-    },
-    "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-      "dev": true
-    },
-    "interpret": {
-      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-      "dev": true
-    },
-    "is-absolute": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "dev": true,
-      "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
-      }
-    },
-    "is-buffer": {
-      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "dev": true
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
-    },
-    "is-generator-function": {
-      "version": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.6.tgz",
-      "integrity": "sha1-nnFlPNFf/zQcecQVFGChMdMen8Q=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
-      }
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
       },
       "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "is-relative": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "dev": true,
-      "requires": {
-        "is-unc-path": "0.1.2"
-      }
-    },
-    "is-unc-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "dev": true,
-      "requires": {
-        "unc-path-regex": "0.1.2"
-      }
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
-      }
-    },
-    "jade": {
-      "version": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "dev": true,
-      "requires": {
-        "commander": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-          "dev": true
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
-        "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-          "dev": true
-        }
-      }
-    },
-    "js2xmlparser": {
-      "version": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-      "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
-      "dev": true
-    },
-    "jsdoc-75lb": {
-      "version": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.5.6.tgz",
-      "integrity": "sha1-OBn7gtWNeBJtdz6LeluCOHz/Omg=",
-      "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz",
-        "catharsis": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.8.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "espree": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-        "js2xmlparser": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-        "requizzle": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-        "taffydb-75lb": "https://registry.npmjs.org/taffydb-75lb/-/taffydb-75lb-2.6.2.tgz",
-        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
-      },
-      "dependencies": {
-        "espree": {
-          "version": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
-          "dev": true
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
-        "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        }
-      }
-    },
-    "jsdoc-api": {
-      "version": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
-      "integrity": "sha1-UBIjWSe/rR4nvIjQew3d2y06ilk=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "cache-point": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.3.tgz",
-        "collect-all": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.2.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-        "file-set": "https://registry.npmjs.org/file-set/-/file-set-1.0.2.tgz",
-        "jsdoc-75lb": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.5.6.tgz",
-        "object-to-spawn-args": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.0.tgz",
-        "promise.prototype.finally": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
-        "temp-path": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-        "then-fs": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
-        "walk-back": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz"
-      },
-      "dependencies": {
-        "collect-all": {
-          "version": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.2.tgz",
-          "integrity": "sha1-OUUPHnqmCGVwoAa86TzPEhinfqE=",
-          "dev": true,
-          "requires": {
-            "stream-connect": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-            "stream-via": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.3.tgz"
-          }
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
-        "stream-via": {
-          "version": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.3.tgz",
-          "integrity": "sha1-zr0ypaWddLO2jjQElC6GcYStSsk=",
-          "dev": true
-        }
-      }
-    },
-    "jsdoc-parse": {
-      "version": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz",
-      "integrity": "sha1-VLdIGzzWvLfBc9xPpp7pJzXqJSU=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
-        "collect-json": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-        "command-line-args": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-        "command-line-tool": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-        "file-set": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
-        "jsdoc-api": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
-        "object-tools": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-        "stream-connect": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-        "test-value": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-all": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz"
-          }
-        },
-        "array-tools": {
-          "version": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
-          "integrity": "sha1-WlEd56Qb4O7J/9zUkS0K+fDKyjU=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-json": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-            "filter-where": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
-            "object-get": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-            "reduce-extract": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-            "reduce-flatten": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-            "reduce-unique": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-            "reduce-without": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-            "sort-array": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.1.tgz",
-            "test-value": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz"
-          }
-        },
-        "command-line-args": {
-          "version": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "command-line-usage": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-            "find-replace": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.2.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-          }
-        },
-        "command-line-tool": {
-          "version": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
-          "integrity": "sha1-kaEbpIrGOkpodVQ2eYD3xkI8FJ0=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz"
-          }
-        },
-        "command-line-usage": {
-          "version": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "column-layout": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
-            "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-            "wordwrapjs": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz"
-          }
-        },
-        "file-set": {
-          "version": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
-          "integrity": "sha1-c6ZXHpy+UaxZJsiL1WfREfg28Xg=",
-          "dev": true,
-          "requires": {
-            "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
-            "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
-          }
-        },
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-          }
-        },
-        "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-          }
-        },
-        "object-tools": {
-          "version": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-          "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-json": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-            "object-get": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-            "test-value": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-          }
-        },
-        "test-value": {
-          "version": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-          }
-        },
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         }
       }
     },
     "jsdoc-to-markdown": {
-      "version": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-1.1.1.tgz",
-      "integrity": "sha1-bvg+vHtByWmqyPEIxgGCvqJKmD8=",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-1.3.9.tgz",
+      "integrity": "sha1-d0wOzg69C8wyYbLJoqqNE5mmFHI=",
       "dev": true,
       "requires": {
-        "command-line-args": "https://registry.npmjs.org/command-line-args/-/command-line-args-0.5.9.tgz",
-        "console-dope": "https://registry.npmjs.org/console-dope/-/console-dope-0.3.6.tgz",
-        "dmd": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
-        "jsdoc-parse": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz"
+        "ansi-escape-sequences": "3.0.0",
+        "command-line-args": "3.0.5",
+        "command-line-usage": "3.0.8",
+        "config-master": "2.0.4",
+        "dmd": "1.4.2",
+        "jsdoc-parse": "1.2.7",
+        "jsdoc2md-stats": "1.0.6",
+        "object-tools": "2.0.6",
+        "stream-connect": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-escape-sequences": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
+          "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "2.6.1"
+          }
+        },
+        "array-tools": {
+          "version": "1.8.6",
+          "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
+          "integrity": "sha1-FFdx9/nJTpjMXqQZapm4MjruGK4=",
+          "dev": true,
+          "requires": {
+            "object-tools": "1.6.7",
+            "typical": "2.6.1"
+          },
+          "dependencies": {
+            "object-tools": {
+              "version": "1.6.7",
+              "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
+              "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
+              "dev": true,
+              "requires": {
+                "array-tools": "1.8.6",
+                "typical": "2.6.1"
+              }
+            }
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "cache-point": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.4.tgz",
+          "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "core-js": "2.5.4",
+            "feature-detect-es6": "1.4.0",
+            "fs-then-native": "1.0.2",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "catharsis": {
+          "version": "0.8.9",
+          "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+          "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+          "dev": true,
+          "requires": {
+            "underscore-contrib": "0.3.0"
+          }
+        },
+        "collect-all": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
+          "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
+          "dev": true,
+          "requires": {
+            "stream-connect": "1.0.2",
+            "stream-via": "0.1.1",
+            "typical": "2.6.1"
+          }
+        },
+        "collect-json": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
+          "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
+          "dev": true,
+          "requires": {
+            "collect-all": "1.0.3",
+            "stream-connect": "1.0.2",
+            "stream-via": "1.0.4"
+          },
+          "dependencies": {
+            "collect-all": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
+              "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+              "dev": true,
+              "requires": {
+                "stream-connect": "1.0.2",
+                "stream-via": "1.0.4"
+              }
+            },
+            "stream-via": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
+              "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+              "dev": true
+            }
+          }
+        },
+        "column-layout": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
+          "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "2.2.2",
+            "array-back": "1.0.4",
+            "collect-json": "1.0.8",
+            "command-line-args": "2.1.6",
+            "core-js": "2.5.4",
+            "deep-extend": "0.4.2",
+            "feature-detect-es6": "1.4.0",
+            "object-tools": "2.0.6",
+            "typical": "2.6.1",
+            "wordwrapjs": "1.2.1"
+          },
+          "dependencies": {
+            "ansi-escape-sequences": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
+              "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "collect-all": "0.2.1"
+              }
+            },
+            "command-line-args": {
+              "version": "2.1.6",
+              "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
+              "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "command-line-usage": "2.0.5",
+                "core-js": "2.5.4",
+                "feature-detect-es6": "1.4.0",
+                "find-replace": "1.0.3",
+                "typical": "2.6.1"
+              }
+            },
+            "command-line-usage": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
+              "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
+              "dev": true,
+              "requires": {
+                "ansi-escape-sequences": "2.2.2",
+                "array-back": "1.0.4",
+                "column-layout": "2.1.4",
+                "feature-detect-es6": "1.4.0",
+                "typical": "2.6.1",
+                "wordwrapjs": "1.2.1"
+              }
+            },
+            "wordwrapjs": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
+              "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "typical": "2.6.1"
+              }
+            }
+          }
+        },
+        "command-line-args": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
+          "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.4.0",
+            "find-replace": "1.0.3",
+            "typical": "2.6.1"
+          }
+        },
+        "command-line-tool": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
+          "integrity": "sha1-+H1pd/VrvdLV38+UY0XdLNnGpTo=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "2.2.2",
+            "array-back": "1.0.4",
+            "command-line-args": "3.0.5",
+            "command-line-usage": "3.0.8",
+            "feature-detect-es6": "1.4.0",
+            "typical": "2.6.1"
+          },
+          "dependencies": {
+            "ansi-escape-sequences": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
+              "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "collect-all": "0.2.1"
+              }
+            }
+          }
+        },
+        "command-line-usage": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
+          "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "3.0.0",
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.4.0",
+            "table-layout": "0.3.0",
+            "typical": "2.6.1"
+          }
+        },
+        "common-sequence": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
+          "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
+          "dev": true
+        },
+        "ddata": {
+          "version": "0.1.28",
+          "resolved": "https://registry.npmjs.org/ddata/-/ddata-0.1.28.tgz",
+          "integrity": "sha1-UxOPr6PwF0nqJFHRK2tt2d8dWx8=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "core-js": "2.5.4",
+            "handlebars": "3.0.3",
+            "marked": "0.3.19",
+            "object-get": "2.1.0",
+            "reduce-flatten": "1.0.1",
+            "string-tools": "1.0.0",
+            "test-value": "2.1.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true
+        },
+        "dmd": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
+          "integrity": "sha1-sTBLmKVwCmv+Xc+RvmV8mBcApLw=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "command-line-tool": "0.5.2",
+            "common-sequence": "1.0.2",
+            "ddata": "0.1.28",
+            "file-set": "1.1.1",
+            "handlebars-array": "0.2.1",
+            "handlebars-comparison": "2.0.1",
+            "handlebars-json": "1.0.1",
+            "handlebars-regexp": "1.0.1",
+            "handlebars-string": "2.0.2",
+            "object-tools": "2.0.6",
+            "reduce-unique": "1.0.0",
+            "reduce-without": "1.0.1",
+            "stream-handlebars": "0.1.6",
+            "string-tools": "1.0.0",
+            "walk-back": "2.0.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "file-set": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
+          "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "glob": "7.1.2"
+          }
+        },
+        "filter-where": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
+          "integrity": "sha1-GwQlae3ONrwcTp9zdA0sTi/u930=",
+          "dev": true,
+          "requires": {
+            "test-value": "1.1.0"
+          },
+          "dependencies": {
+            "test-value": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+              "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "typical": "2.6.1"
+              }
+            }
+          }
+        },
+        "find-replace": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+          "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "test-value": "2.1.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true,
+          "optional": true
+        },
+        "handlebars-array": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
+          "integrity": "sha1-3Vg5WlJh1mGYjo13Ug67+q3GvSQ=",
+          "dev": true,
+          "requires": {
+            "array-tools": "1.8.6"
+          }
+        },
+        "handlebars-comparison": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
+          "integrity": "sha1-sXuV0sKYV45K6tOPX6xG6PYAWFU=",
+          "dev": true,
+          "requires": {
+            "array-tools": "1.8.6"
+          }
+        },
+        "handlebars-json": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
+          "integrity": "sha1-Lvh7t4JVHNZFu0aRuCTpZT7AJQQ=",
+          "dev": true
+        },
+        "handlebars-regexp": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
+          "integrity": "sha1-X0fwZyYOm6jlLxooCRf3DeOfEeQ=",
+          "dev": true
+        },
+        "handlebars-string": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
+          "integrity": "sha1-ufkiCKl5z89R/0qQ3voYPcYpQso=",
+          "dev": true,
+          "requires": {
+            "array-tools": "1.8.6",
+            "string-tools": "0.1.8"
+          },
+          "dependencies": {
+            "string-tools": {
+              "version": "0.1.8",
+              "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
+              "integrity": "sha1-cIhOhqJu5RA6B4vvZwM9VY024zc=",
+              "dev": true
+            }
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "js2xmlparser": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
+          "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
+          "dev": true
+        },
+        "jsdoc-75lb": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
+          "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
+          "dev": true,
+          "requires": {
+            "bluebird": "3.4.7",
+            "catharsis": "0.8.9",
+            "escape-string-regexp": "1.0.5",
+            "espree": "3.1.7",
+            "js2xmlparser": "1.0.0",
+            "klaw": "1.3.1",
+            "marked": "0.3.19",
+            "mkdirp": "0.5.1",
+            "requizzle": "0.2.1",
+            "strip-json-comments": "2.0.1",
+            "taffydb": "2.6.2",
+            "underscore": "1.8.3"
+          }
+        },
+        "jsdoc-api": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
+          "integrity": "sha1-UBIjWSe/rR4nvIjQew3d2y06ilk=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "cache-point": "0.3.4",
+            "collect-all": "1.0.3",
+            "core-js": "2.5.4",
+            "feature-detect-es6": "1.4.0",
+            "file-set": "1.1.1",
+            "jsdoc-75lb": "3.6.0",
+            "object-to-spawn-args": "1.1.1",
+            "promise.prototype.finally": "1.0.1",
+            "temp-path": "1.0.0",
+            "then-fs": "2.0.0",
+            "walk-back": "2.0.1"
+          },
+          "dependencies": {
+            "collect-all": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
+              "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+              "dev": true,
+              "requires": {
+                "stream-connect": "1.0.2",
+                "stream-via": "1.0.4"
+              }
+            },
+            "stream-via": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
+              "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+              "dev": true
+            }
+          }
+        },
+        "jsdoc-parse": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz",
+          "integrity": "sha1-VLdIGzzWvLfBc9xPpp7pJzXqJSU=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "2.2.2",
+            "array-tools": "2.0.9",
+            "collect-json": "1.0.8",
+            "command-line-args": "2.1.6",
+            "command-line-tool": "0.1.0",
+            "core-js": "2.5.4",
+            "feature-detect-es6": "1.4.0",
+            "file-set": "0.2.8",
+            "jsdoc-api": "1.2.4",
+            "object-tools": "2.0.6",
+            "stream-connect": "1.0.2",
+            "test-value": "1.1.0"
+          },
+          "dependencies": {
+            "ansi-escape-sequences": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
+              "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "collect-all": "0.2.1"
+              }
+            },
+            "array-tools": {
+              "version": "2.0.9",
+              "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
+              "integrity": "sha1-WlEd56Qb4O7J/9zUkS0K+fDKyjU=",
+              "dev": true,
+              "requires": {
+                "ansi-escape-sequences": "2.2.2",
+                "array-back": "1.0.4",
+                "collect-json": "1.0.8",
+                "filter-where": "1.0.1",
+                "object-get": "2.1.0",
+                "reduce-extract": "1.0.0",
+                "reduce-flatten": "1.0.1",
+                "reduce-unique": "1.0.0",
+                "reduce-without": "1.0.1",
+                "sort-array": "1.1.2",
+                "test-value": "1.1.0"
+              }
+            },
+            "command-line-args": {
+              "version": "2.1.6",
+              "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
+              "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "command-line-usage": "2.0.5",
+                "core-js": "2.5.4",
+                "feature-detect-es6": "1.4.0",
+                "find-replace": "1.0.3",
+                "typical": "2.6.1"
+              }
+            },
+            "command-line-tool": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
+              "integrity": "sha1-kaEbpIrGOkpodVQ2eYD3xkI8FJ0=",
+              "dev": true,
+              "requires": {
+                "ansi-escape-sequences": "2.2.2",
+                "array-back": "1.0.4"
+              }
+            },
+            "command-line-usage": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
+              "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
+              "dev": true,
+              "requires": {
+                "ansi-escape-sequences": "2.2.2",
+                "array-back": "1.0.4",
+                "column-layout": "2.1.4",
+                "feature-detect-es6": "1.4.0",
+                "typical": "2.6.1",
+                "wordwrapjs": "1.2.1"
+              }
+            },
+            "file-set": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
+              "integrity": "sha1-c6ZXHpy+UaxZJsiL1WfREfg28Xg=",
+              "dev": true,
+              "requires": {
+                "array-tools": "2.0.9",
+                "glob": "4.5.3"
+              }
+            },
+            "glob": {
+              "version": "4.5.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "2.0.10",
+                "once": "1.4.0"
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              }
+            },
+            "test-value": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+              "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "typical": "2.6.1"
+              }
+            },
+            "wordwrapjs": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
+              "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "typical": "2.6.1"
+              }
+            }
+          }
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "marked": {
+          "version": "0.3.19",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "object-get": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
+          "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
+          "dev": true
+        },
+        "object-to-spawn-args": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
+          "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+          "dev": true
+        },
+        "object-tools": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
+          "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "collect-json": "1.0.8",
+            "object-get": "2.1.0",
+            "test-value": "1.1.0",
+            "typical": "2.6.1"
+          },
+          "dependencies": {
+            "test-value": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+              "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "typical": "2.6.1"
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "dev": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "promise.prototype.finally": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
+          "integrity": "sha1-kRgvkckkhplXQPoF4NqUKsmGvvo=",
+          "dev": true
+        },
+        "reduce-extract": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
+          "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+          "dev": true,
+          "requires": {
+            "test-value": "1.1.0"
+          },
+          "dependencies": {
+            "test-value": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+              "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4",
+                "typical": "2.6.1"
+              }
+            }
+          }
+        },
+        "reduce-flatten": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+          "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+          "dev": true
+        },
+        "reduce-unique": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
+          "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
+          "dev": true
+        },
+        "reduce-without": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
+          "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+          "dev": true,
+          "requires": {
+            "test-value": "2.1.0"
+          }
+        },
+        "requizzle": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+          "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+          "dev": true,
+          "requires": {
+            "underscore": "1.6.0"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+              "dev": true
+            }
+          }
+        },
+        "sort-array": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
+          "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "object-get": "2.1.0",
+            "typical": "2.6.1"
+          }
+        },
+        "stream-connect": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+          "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "stream-handlebars": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
+          "integrity": "sha1-cwW1BkID2hcWCMR4rPZCoUmJKi8=",
+          "dev": true,
+          "requires": {
+            "handlebars": "3.0.3",
+            "object-tools": "1.6.7"
+          },
+          "dependencies": {
+            "object-tools": {
+              "version": "1.6.7",
+              "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
+              "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
+              "dev": true,
+              "requires": {
+                "array-tools": "1.8.6",
+                "typical": "2.6.1"
+              }
+            }
+          }
+        },
+        "stream-via": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
+          "integrity": "sha1-DO5d+clZ+x0/TtpIGfKJ1fkgWvw=",
+          "dev": true
+        },
+        "string-tools": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
+          "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
+          "dev": true
+        },
+        "table-layout": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
+          "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "core-js": "2.5.4",
+            "deep-extend": "0.4.2",
+            "feature-detect-es6": "1.4.0",
+            "typical": "2.6.1",
+            "wordwrapjs": "2.0.0"
+          }
+        },
+        "temp-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
+          "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+          "dev": true
+        },
+        "test-value": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
+          }
+        },
+        "then-fs": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
+          "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
+          "dev": true,
+          "requires": {
+            "promise": "7.3.1"
+          }
+        },
+        "typical": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        },
+        "underscore-contrib": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+          "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+          "dev": true,
+          "requires": {
+            "underscore": "1.6.0"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+              "dev": true
+            }
+          }
+        },
+        "walk-back": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+          "dev": true
+        },
+        "wordwrapjs": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
+          "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.4.0",
+            "reduce-flatten": "1.0.1",
+            "typical": "2.6.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        }
       }
     },
-    "jsonfile": {
-      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+    "jsdoc2md-stats": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/jsdoc2md-stats/-/jsdoc2md-stats-1.0.6.tgz",
+      "integrity": "sha1-3A4AKuu9D7rlEjU0+Scyr7xlH78=",
       "dev": true,
       "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+        "app-usage-stats": "0.4.1",
+        "feature-detect-es6": "1.4.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "2.6.1"
+          }
+        },
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "typical": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "dev": true
+        }
       }
-    },
-    "keygrip": {
-      "version": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz",
-      "integrity": "sha1-sC+kgW7vIajEs1yp5Skh/8iaMOk=",
-      "dev": true
-    },
-    "kind-of": {
-      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-      "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
-      }
-    },
-    "klaw": {
-      "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-      "integrity": "sha1-iFe/vB2CS63xPT0CQdi75G+xL3M=",
-      "dev": true
     },
     "koa": {
-      "version": "https://registry.npmjs.org/koa/-/koa-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.2.0.tgz",
       "integrity": "sha1-sFWTMYeEnVQK2Ln3MbqqS+l8ZS0=",
       "dev": true,
       "requires": {
-        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-        "content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-        "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-        "cookies": "https://registry.npmjs.org/cookies/-/cookies-0.7.0.tgz",
+        "accepts": "1.3.5",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookies": "0.7.1",
         "debug": "3.1.0",
-        "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-        "error-inject": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-        "http-assert": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-        "is-generator-function": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.6.tgz",
-        "koa-compose": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.1.0.tgz",
-        "koa-convert": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
-        "koa-is-json": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "only": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-        "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+        "delegates": "1.0.0",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "error-inject": "1.0.0",
+        "escape-html": "1.0.3",
+        "fresh": "0.5.2",
+        "http-assert": "1.3.0",
+        "http-errors": "1.6.3",
+        "is-generator-function": "1.0.7",
+        "koa-compose": "3.2.1",
+        "koa-convert": "1.2.0",
+        "koa-is-json": "1.0.0",
+        "mime-types": "2.1.18",
+        "on-finished": "2.3.0",
+        "only": "0.0.2",
+        "parseurl": "1.3.2",
+        "statuses": "1.5.0",
+        "type-is": "1.6.16",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+          "dev": true,
+          "requires": {
+            "mime-types": "2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "dev": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+          "dev": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+          "dev": true
+        },
+        "cookies": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
+          "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.2",
+            "keygrip": "1.0.2"
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "dev": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+          "dev": true
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+          "dev": true
+        },
+        "error-inject": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
+          "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=",
+          "dev": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+          "dev": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true
+        },
+        "http-assert": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
+          "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
+          "dev": true,
+          "requires": {
+            "deep-equal": "1.0.1",
+            "http-errors": "1.6.3"
+          }
+        },
+        "is-generator-function": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+          "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+          "dev": true
+        },
+        "keygrip": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
+          "integrity": "sha1-rTKXxVcGneqLz+ek+kkbdcXd65E=",
+          "dev": true
+        },
+        "koa-convert": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
+          "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "koa-compose": "3.2.1"
+          }
+        },
+        "koa-is-json": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
+          "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ=",
+          "dev": true
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+          "dev": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "only": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+          "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
+          "dev": true
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+          "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+          "dev": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.18"
+          }
+        },
+        "vary": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+          "dev": true
+        }
       }
     },
     "koa-compose": {
-      "version": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.1.0.tgz",
-      "integrity": "sha1-9uMvG4lT98h7l/wQwgj+0zTadvQ=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+      "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
       "requires": {
-        "any-promise": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
+        "any-promise": "1.3.0"
+      },
+      "dependencies": {
+        "any-promise": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+        }
       }
     },
-    "koa-convert": {
-      "version": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
-      "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
-      "dev": true,
-      "requires": {
-        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-        "koa-compose": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.1.0.tgz"
-      }
-    },
-    "koa-is-json": {
-      "version": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
-      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ=",
-      "dev": true
-    },
-    "liftoff": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
-      "dev": true,
-      "requires": {
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-        "findup-sync": "0.4.3",
-        "fined": "1.1.0",
-        "flagged-respawn": "0.3.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mapvalues": "4.6.0",
-        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash._reescape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-      "dev": true
-    },
-    "lodash._reevaluate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-      "dev": true
-    },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-      "dev": true
-    },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "3.0.1"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-      "dev": true
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
-    },
-    "lodash.template": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
-      }
-    },
-    "lru-cache": {
-      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
-    },
-    "map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
-    },
-    "marked": {
-      "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
-      "dev": true
-    },
-    "media-typer": {
-      "version": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
     },
     "methods": {
-      "version": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
-      }
-    },
-    "mime": {
-      "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+    "mkdirp2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz",
+      "integrity": "sha1-zI3YJl8fBuLY9bELblL04FC+0hs=",
       "dev": true
-    },
-    "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-      "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-      "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
-      "dev": true,
-      "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
-      }
-    },
-    "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-      }
-    },
-    "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-      }
     },
     "mocha": {
-      "version": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
-      "integrity": "sha1-Whboi4VtDEFF2MaIjCfr1PqxPpA=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
       "requires": {
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-        "diff": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
         "escape-string-regexp": "1.0.2",
-        "glob": "3.2.3",
-        "growl": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
-        "jade": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-        "mkdirp": "0.5.0"
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-          "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            "ms": "0.7.1"
           }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.2",
@@ -2230,42 +1802,98 @@
           "dev": true
         },
         "glob": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
           }
         },
-        "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "jade": {
+          "version": "0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+          "dev": true,
+          "requires": {
+            "commander": "0.6.1",
+            "mkdirp": "0.3.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+              "dev": true
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
           "dev": true
         },
         "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
         "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "sigmund": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+          "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
           "dev": true
         }
       }
@@ -2275,475 +1903,65 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.0.2"
-      }
-    },
-    "natives": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
-      "dev": true
-    },
-    "nature": {
-      "version": "https://registry.npmjs.org/nature/-/nature-0.5.7.tgz",
-      "integrity": "sha1-KrdUC6R0RhZawJU99g3ICBvpIjM=",
-      "dev": true,
-      "requires": {
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-        "object-tools": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-1.0.0.tgz"
-      }
-    },
-    "negotiator": {
-      "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
-    },
-    "object-get": {
-      "version": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
-      "dev": true
-    },
-    "object-to-spawn-args": {
-      "version": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.0.tgz",
-      "integrity": "sha1-AxogDjfbLD38m5gHSg1ppb4lPBw=",
-      "dev": true
-    },
-    "object-tools": {
-      "version": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-      "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-      "dev": true,
-      "requires": {
-        "array-tools": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "object.defaults": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
-      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
-      "dev": true,
-      "requires": {
-        "array-each": "1.0.1",
-        "array-slice": "1.0.0",
-        "for-own": "1.0.0",
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "for-own": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
-    },
-    "object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "on-finished": {
-      "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-      }
-    },
-    "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      }
-    },
-    "only": {
-      "version": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
-      "dev": true
-    },
-    "optimist": {
-      "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
-    "orchestrator": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "0.1.5",
-        "sequencify": "0.0.7",
-        "stream-consume": "0.1.0"
-      }
-    },
-    "ordered-read-streams": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-      "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-      "dev": true
-    },
-    "os-homedir": {
-      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "parse-filepath": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-      "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
-      "dev": true,
-      "requires": {
-        "is-absolute": "0.2.6",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
-    },
-    "parseurl": {
-      "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-root": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "dev": true,
-      "requires": {
-        "path-root-regex": "0.1.2"
-      }
-    },
-    "path-root-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-      "dev": true
-    },
     "path-to-regexp": {
-      "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz",
-      "integrity": "sha1-ciHd1CSDU4vd+f6tlCp5/zFk9Xo=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "requires": {
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-      }
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
-    "pretty-hrtime": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
-    "promise": {
-      "version": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
-      "dev": true,
-      "requires": {
-        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
-      }
-    },
-    "promise.prototype.finally": {
-      "version": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
-      "integrity": "sha1-kRgvkckkhplXQPoF4NqUKsmGvvo=",
-      "dev": true
-    },
-    "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-      "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
-      "dev": true
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "isarray": "0.0.1"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-          "dev": true
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
-    "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-      "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-      }
-    },
-    "rechoir": {
-      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-      }
-    },
-    "reduce-component": {
-      "version": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
       "dev": true
     },
-    "reduce-extract": {
-      "version": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+    "req-then": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/req-then/-/req-then-0.5.1.tgz",
+      "integrity": "sha1-McbgtW9N3SrNbeC6G86ne2B5398=",
       "dev": true,
       "requires": {
-        "test-value": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz"
+        "array-back": "1.0.4",
+        "defer-promise": "1.0.1",
+        "feature-detect-es6": "1.4.0",
+        "lodash.pick": "4.4.0",
+        "typical": "2.6.1"
       },
       "dependencies": {
-        "test-value": {
-          "version": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+            "typical": "2.6.1"
+          }
+        },
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
           }
         },
         "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
       }
-    },
-    "reduce-flatten": {
-      "version": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
-      "dev": true
-    },
-    "reduce-unique": {
-      "version": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
-      "dev": true
-    },
-    "reduce-without": {
-      "version": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
-      "dev": true,
-      "requires": {
-        "test-value": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
-    },
-    "repeat-string": {
-      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
-      "dev": true
-    },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-      "dev": true
-    },
-    "requizzle": {
-      "version": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
-      "dev": true,
-      "requires": {
-        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
-      }
-    },
-    "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
-    },
-    "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
-      }
-    },
-    "rimraf": {
-      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-      "dev": true,
-      "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz"
-      }
-    },
-    "sequencify": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-      "dev": true
-    },
-    "setprototypeof": {
-      "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
-      "integrity": "sha1-UgCbJ4iMTcSPWRlJwKgnWDTByn4="
     },
     "should": {
       "version": "6.0.3",
@@ -2782,156 +2000,72 @@
         }
       }
     },
-    "sigmund": {
-      "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
-    "sort-array": {
-      "version": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.1.tgz",
-      "integrity": "sha1-kDL28L4oTuyxKvmKPbAmEoKKZtE=",
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "dev": true,
       "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "object-get": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
+        "amdefine": "1.0.1"
       },
       "dependencies": {
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
+        "amdefine": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         }
       }
     },
-    "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "statuses": {
-      "version": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-      "integrity": "sha1-jlV1jLIOdoLB9Pzo3KswvwHR4Ho="
-    },
-    "stream-connect": {
-      "version": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+    "supertest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-1.2.0.tgz",
+      "integrity": "sha1-hQp5X5Bo0vrxngF5n/CZYuDOQ74=",
       "dev": true,
       "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz"
-      }
-    },
-    "stream-consume": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
-      "dev": true
-    },
-    "stream-handlebars": {
-      "version": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
-      "integrity": "sha1-cwW1BkID2hcWCMR4rPZCoUmJKi8=",
-      "dev": true,
-      "requires": {
-        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-        "object-tools": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz"
+        "methods": "1.1.2",
+        "superagent": "1.8.5"
       },
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
         },
-        "handlebars": {
-          "version": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz"
+            "delayed-stream": "1.0.0"
           }
         },
-        "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-          }
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
         },
-        "uglify-js": {
-          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-              }
-            }
-          }
+        "cookiejar": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+          "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
+          "dev": true
         },
-        "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "stream-via": {
-      "version": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
-      "integrity": "sha1-DO5d+clZ+x0/TtpIGfKJ1fkgWvw=",
-      "dev": true
-    },
-    "string-tools": {
-      "version": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
-      "integrity": "sha1-cIhOhqJu5RA6B4vvZwM9VY024zc=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
-    "strip-ansi": {
-      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-      }
-    },
-    "superagent": {
-      "version": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz",
-      "integrity": "sha1-aLLIpADxdT3bOUEJBomeQvQg/To=",
-      "dev": true,
-      "requires": {
-        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-        "cookiejar": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-        "debug": "2.6.9",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-        "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-        "formidable": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-        "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-        "reduce-component": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
-      },
-      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2940,112 +2074,36 @@
           "requires": {
             "ms": "2.0.0"
           }
-        }
-      }
-    },
-    "supertest": {
-      "version": "https://registry.npmjs.org/supertest/-/supertest-1.2.0.tgz",
-      "integrity": "sha1-hQp5X5Bo0vrxngF5n/CZYuDOQ74=",
-      "dev": true,
-      "requires": {
-        "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-        "superagent": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz"
-      }
-    },
-    "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "table-layout": {
-      "version": "https://registry.npmjs.org/table-layout/-/table-layout-0.2.2.tgz",
-      "integrity": "sha1-WD15LPWBFDgKIqysNDBfd2dHIQ0=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "collect-json": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-        "command-line-args": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.1.tgz",
-        "command-line-usage": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.3.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-        "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-        "wordwrapjs": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "1.0.0-rc3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+          "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
           "dev": true,
           "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "collect-all": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz"
+            "async": "1.5.2",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
-        "command-line-args": {
-          "version": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.1.tgz",
-          "integrity": "sha1-YXusChXTSuhI7aKqUT7Xbv3EivU=",
-          "dev": true,
-          "requires": {
-            "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "feature-detect-es6": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-            "find-replace": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.2.tgz",
-            "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-          }
+        "formidable": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+          "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
+          "dev": true
         },
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "taffydb-75lb": {
-      "version": "https://registry.npmjs.org/taffydb-75lb/-/taffydb-75lb-2.6.2.tgz",
-      "integrity": "sha1-ccePa4zQit97TBb9JEP56VKdar8=",
-      "dev": true
-    },
-    "temp-path": {
-      "version": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
-      "dev": true
-    },
-    "test-value": {
-      "version": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
-          "dev": true
-        }
-      }
-    },
-    "then-fs": {
-      "version": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
-      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
-      "dev": true,
-      "requires": {
-        "promise": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
-      }
-    },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      },
-      "dependencies": {
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -3053,271 +2111,190 @@
           "dev": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+        "mime": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
           "dev": true
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "tildify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-      }
-    },
-    "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-      "dev": true
-    },
-    "type-is": {
-      "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
-      "requires": {
-        "media-typer": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-      },
-      "dependencies": {
         "mime-db": {
-          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
           "dev": true
         },
         "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+            "mime-db": "1.33.0"
+          }
+        },
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.27-1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+          "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "reduce-component": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+          "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "superagent": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.5.tgz",
+          "integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U=",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.0.6",
+            "debug": "2.6.9",
+            "extend": "3.0.0",
+            "form-data": "1.0.0-rc3",
+            "formidable": "1.0.17",
+            "methods": "1.1.2",
+            "mime": "1.3.4",
+            "qs": "2.3.3",
+            "readable-stream": "1.0.27-1",
+            "reduce-component": "1.0.1"
           }
         }
       }
     },
-    "typical": {
-      "version": "https://registry.npmjs.org/typical/-/typical-1.0.0.tgz",
-      "integrity": "sha1-ICKvXxHnEV6WD4h8ngtosxPF1vA=",
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
-    "unc-path-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
     },
-    "underscore": {
-      "version": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
-    },
-    "underscore-contrib": {
-      "version": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+    "uglify-js": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        "async": "0.2.10",
+        "optimist": "0.3.7",
+        "source-map": "0.1.43"
       },
       "dependencies": {
-        "underscore": {
-          "version": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true,
+          "optional": true
+        },
+        "optimist": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
         }
       }
-    },
-    "unique-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-      "dev": true
     },
     "urijs": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.0.tgz",
       "integrity": "sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw=="
     },
-    "util-deprecate": {
-      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+    "usage-stats": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/usage-stats/-/usage-stats-0.8.6.tgz",
+      "integrity": "sha512-QS1r7a1h5g1jo6KulvVGV+eQM+Jfj87AjJBfr1iaIJYz+N7+Qh7ezaVFCulwBGd8T1EidRiSYphG17gra2y0kg==",
       "dev": true,
       "requires": {
-        "user-home": "1.1.1"
+        "array-back": "1.0.4",
+        "cli-commands": "0.1.0",
+        "core-js": "2.5.4",
+        "feature-detect-es6": "1.4.0",
+        "home-path": "1.0.5",
+        "mkdirp2": "1.0.3",
+        "req-then": "0.5.1",
+        "typical": "2.6.1",
+        "uuid": "3.2.1"
       },
       "dependencies": {
-        "user-home": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-          "dev": true
-        }
-      }
-    },
-    "vary": {
-      "version": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
-      "dev": true
-    },
-    "vinyl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.2",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
-      }
-    },
-    "vinyl-fs": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-      "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-      "dev": true,
-      "requires": {
-        "defaults": "1.0.3",
-        "glob-stream": "3.1.18",
-        "glob-watcher": "0.0.6",
-        "graceful-fs": "3.0.11",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "strip-bom": "1.0.0",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "2.6.1"
+          }
+        },
+        "core-js": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
           "dev": true
         },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+        "feature-detect-es6": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+          "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "array-back": "1.0.4"
           }
         },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
-        },
-        "strip-bom": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-          "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-          "dev": true,
-          "requires": {
-            "first-chunk-stream": "1.0.0",
-            "is-utf8": "0.2.1"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
-        }
-      }
-    },
-    "walk-back": {
-      "version": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-      "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
-      "dev": true
-    },
-    "word-wrap": {
-      "version": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz",
-      "integrity": "sha1-NWFT1h0QYQ1gB4XF1wEojgrnZKY=",
-      "dev": true
-    },
-    "wordwrapjs": {
-      "version": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
-      "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
-      "dev": true,
-      "requires": {
-        "array-back": "https://registry.npmjs.org/array-back/-/array-back-1.0.3.tgz",
-        "typical": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz"
-      },
-      "dependencies": {
         "typical": {
-          "version": "https://registry.npmjs.org/typical/-/typical-2.6.0.tgz",
-          "integrity": "sha1-idUVVKsTmEimW8wsh3L4+0UMQO0=",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
       }
     },
-    "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
-    "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     }
   }


### PR DESCRIPTION
I just add the `path` of the `layer` in the context `ctx` during the memo middleware. The last value set to `ctx.routerPath` is the route not calling `next()`, for my usage of koa-router it corresponds to the route I call the matching route. 

Maybe this help for #444 ?