### PR TITLE
Fix selection of most specific layer (for _matchedRoute)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -207,6 +207,27 @@ methods.forEach(function (method) {
   };
 });
 
+/**
+ * Sort function for array of Layers. Will sort the layers with least specific first
+ * and most specific last
+ * @param {Layer} a
+ * @param {Layer} b
+ */
+function sortByMostSpecificLayer(a, b) {
+  var wildA = a.path.endsWith('(.*)');
+  var wildB = b.path.endsWith('(.*)');
+  if (wildA && wildB) return a.path.length - b.path.length;
+  var pathA = wildA ? a.path.slice(0, -4) : a.path;
+  var pathB = wildB ? b.path.slice(0, -4) : b.path;
+  if (pathA !== pathB) {
+    if (pathA.startsWith(pathB)) return 1;
+    if (pathB.startsWith(pathA)) return -1;
+  }
+  if (wildA) return -1;
+  if (wildB) return 1;
+  return 0;
+}
+
 // Alias for `router.delete()` because delete is a reserved word
 Router.prototype.del = Router.prototype['delete'];
 
@@ -332,6 +353,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
     if (!matched.route) return next();
 
     var matchedLayers = matched.pathAndMethod
+    matchedLayers.sort(sortByMostSpecificLayer);
     var mostSpecificLayer = matchedLayers[matchedLayers.length - 1]
     ctx._matchedRoute = mostSpecificLayer.path;
     if (mostSpecificLayer.name) {


### PR DESCRIPTION
Fix for issue #444.

As layers are in arbitrary order, they need to be sorted before selecting the most specific layer.