### PR TITLE
Fix the merge relationship between `prefix` and `path`

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -213,7 +213,8 @@ Layer.prototype.param = function (param, fn) {
 
 Layer.prototype.setPrefix = function (prefix) {
   if (this.path) {
-    this.path = prefix + this.path;
+    // Fix bug with function of join.
+    this.path = join(prefix, this.path);
     this.paramNames = [];
     this.regexp = pathToRegExp(this.path, this.paramNames, this.opts);
   }
@@ -236,4 +237,21 @@ function safeDecodeURIComponent(text) {
   } catch (e) {
     return text;
   }
+}
+
+/**
+ * Fix the merge relationship between `prefix` and `path`, 
+ * so that `path-to-regexp` can correctly parse the regular expression
+ * 
+ * @param {String} prefix 
+ * @param {String} path 
+ * @return {String} Combined results
+ * @private
+ */
+
+function join(prefix, path) {
+  if (!prefix) prefix = '/';
+  if (/\/$/.test(prefix)) prefix = prefix.replace(/\/$/, '');
+  if (!/^\//.test(path)) path = '/' + path;
+  return prefix + (path === '/' ? '' : path);
 }

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -243,6 +243,15 @@ function safeDecodeURIComponent(text) {
  * Fix the merge relationship between `prefix` and `path`, 
  * so that `path-to-regexp` can correctly parse the regular expression
  * 
+ * Example:
+ *  prefix        path          result
+ *  `/a/b`        `/`           `/a/b`
+ *  `/a/b`        `/c/d`        `/a/b/c/d`
+ *  `/`           `/a/b`        `/a/b`
+ *  `/`           `/`           `/`
+ *  `/abc`        `abc/`        `/abc/abc/`
+ *  `/abc`        `/abc/`       `/abc/abc/`
+ * 
  * @param {String} prefix 
  * @param {String} path 
  * @return {String} Combined results


### PR DESCRIPTION
Fix the merge relationship between `prefix` and `path`, so that `path-to-regexp` can correctly parse the regular expression.

I found the bug:

```javascript
const Koa = require('koa');
const Router = require('koa-router');

const app = new Koa();
const router = new Router();

const test = new Router();

test.get('/test', async (ctx, next) => {
  ctx.body = 'hello world';
});

router.use('/abc', test.routes(), test.allowedMethods());

app.use(router.routes());
app.use(router.allowedMethods());

app.listen(9000);
```

When i view '/abc/test' , the result is '404';

I fixed it. 

Thanks!