### PR TITLE
Fix the merge relationship between `prefix` and `path`

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -213,7 +213,14 @@ Layer.prototype.param = function (param, fn) {
 
 Layer.prototype.setPrefix = function (prefix) {
   if (this.path) {
-    this.path = prefix + this.path;
+    /**
+     * Fix the merge relationship between prefix and path, 
+     * so that path-to-regexp can correctly parse the regular expression.
+     * @example:
+     * when prefix is '/' and path is '/'
+     * then get '//'
+     */
+    this.path = (prefix + this.path).replace(/[\/]+/g, '/');
     this.paramNames = [];
     this.regexp = pathToRegExp(this.path, this.paramNames, this.opts);
   }


### PR DESCRIPTION
Fix the merge relationship between `prefix` and `path`, so that `path-to-regexp` can correctly parse the regular expression.

I found the bug:

```javascript
const Koa = require('koa');
const Router = require('koa-router');

const app = new Koa();
const router = new Router();

const test = new Router();

test.get('/test', async (ctx, next) => {
  ctx.body = 'hello world';
});

router.use('/abc', test.routes(), test.allowedMethods());

app.use(router.routes());
app.use(router.allowedMethods());

app.listen(9000);
```

When i view '/abc/test' , the result is '404';


if 


```javascript
test.get('/', async (ctx, next) => {
  ctx.body = 'hello world';
});
router.use('/', test.routes(), test.allowedMethods());
```

Also got 404. I fixed it. Thanks!