### PR TITLE
populate `ctx.params` before running any matched middleware

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -64,15 +64,13 @@ Layer.prototype.match = function (path) {
 /**
  * Returns map of URL parameters for given `path` and `paramNames`.
  *
- * @param {String} path
  * @param {Array.<String>} captures
- * @param {Object=} existingParams
  * @returns {Object}
  * @private
  */
 
-Layer.prototype.params = function (path, captures, existingParams) {
-  var params = existingParams || {};
+Layer.prototype.params = function (captures) {
+  var params = {};
 
   for (var len = captures.length, i=0; i<len; i++) {
     if (this.paramNames[i]) {
@@ -93,7 +91,6 @@ Layer.prototype.params = function (path, captures, existingParams) {
  */
 
 Layer.prototype.captures = function (path) {
-  if (this.opts.ignoreCaptures) return [];
   return path.match(this.regexp).slice(1);
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -273,7 +273,7 @@ Router.prototype.use = function () {
         });
       }
     } else {
-      router.register(path || '(.*)', [], m, { end: false, ignoreCaptures: !hasPath });
+      router.register(path || '(.*)', [], m, { end: false });
     }
   });
 
@@ -334,14 +334,13 @@ Router.prototype.routes = Router.prototype.middleware = function () {
     var matchedLayers = matched.pathAndMethod
     var mostSpecificLayer = matchedLayers[matchedLayers.length - 1]
     ctx._matchedRoute = mostSpecificLayer.path;
+    ctx.params = mostSpecificLayer.params( mostSpecificLayer.captures(path) )
     if (mostSpecificLayer.name) {
       ctx._matchedRouteName = mostSpecificLayer.name;
     }
 
     layerChain = matchedLayers.reduce(function(memo, layer) {
       memo.push(function(ctx, next) {
-        ctx.captures = layer.captures(path, ctx.captures);
-        ctx.params = layer.params(path, ctx.captures, ctx.params);
         ctx.routerName = layer.name;
         return next();
       });
@@ -556,7 +555,6 @@ Router.prototype.register = function (path, methods, middleware, opts) {
     sensitive: opts.sensitive || this.opts.sensitive || false,
     strict: opts.strict || this.opts.strict || false,
     prefix: opts.prefix || this.opts.prefix || "",
-    ignoreCaptures: opts.ignoreCaptures
   });
 
   if (this.opts.prefix) {


### PR DESCRIPTION
The problem is that when I use `router.use(someMiddleware)`, in that middleware I have access to payload from query string via `ctx.query` and to payload from request body via `ctx.request.body` but I haven't access to **route params** and this is not so convenient especially in my case.

To be more clear I will tell my story. I have a validation middleware which works like this.
It takes **request method** from `ctx.request.method` and **matched route** from `ctx._matchedRoute` and using that it takes necessary **validation rules** from **validation schemas** that look like this:

```
'PUT:/users/:id': {
    params: Joi.object().keys({
        id: Joi.string().length(24).alphanum().required(),
    }),

    query: Joi.object().keys(definitions),

    body: Joi.object().keys(definitions)
}
```

and for each type of payload, if it exists in the scheme, it checks for validity and **problem** comes here when it tries to validate **params** because **params** are not available in the **middleware** defined using `router.use` method.

This pull request fixes this type of problems and I think this will will bring much good in the future.

Thanks!
